### PR TITLE
#281040 expose all customer requirement query types

### DIFF
--- a/src/modules/TicketsDataProvider.ts
+++ b/src/modules/TicketsDataProvider.ts
@@ -78,7 +78,7 @@ const HISTORICAL_WORK_ITEM_FIELDS = [
 
 /** Default fields fetched per work item in tree/flat query parsing. */
 const WI_DEFAULT_FIELDS =
-  'System.Description,System.Title,Microsoft.VSTS.TCM.ReproSteps,Microsoft.VSTS.CMMI.Symptom';
+  'System.Description,System.Title,System.WorkItemType,Microsoft.VSTS.TCM.ReproSteps,Microsoft.VSTS.CMMI.Symptom';
 
 export default class TicketsDataProvider {
   orgUrl: string = '';
@@ -691,6 +691,58 @@ export default class TicketsDataProvider {
     return { systemRequirementsQueryTree };
   }
 
+  private async fetchCustomerRequirementQueries(queries: any) {
+    const systemRequirementsQueryTree = await this.structureCustomerRequirementQueries(queries);
+    return { systemRequirementsQueryTree };
+  }
+
+  private async structureCustomerRequirementQueries(
+    rootQuery: any,
+    parentId: any = null,
+  ): Promise<any> {
+    try {
+      if (!rootQuery?.hasChildren) {
+        const isExecutableQuery =
+          !rootQuery?.isFolder && ['flat', 'tree', 'oneHop'].includes(rootQuery?.queryType);
+        return isExecutableQuery ? this.buildQueryNode(rootQuery, parentId) : null;
+      }
+
+      if (!rootQuery.children) {
+        const queryUrl = `${rootQuery.url}?$depth=2&$expand=all`;
+        const currentQuery = await TFSServices.getItemContent(queryUrl, this.token);
+        if (!currentQuery) {
+          return null;
+        }
+        return await this.structureCustomerRequirementQueries(currentQuery, currentQuery.id);
+      }
+
+      const childResults = await Promise.all(
+        rootQuery.children.map((child: any) =>
+          this.structureCustomerRequirementQueries(child, rootQuery.id),
+        ),
+      );
+      const children = childResults.filter((child: any) => child !== null);
+
+      return children.length > 0
+        ? {
+            id: rootQuery.id,
+            pId: parentId,
+            value: rootQuery.name,
+            title: rootQuery.name,
+            children,
+          }
+        : null;
+    } catch (err: any) {
+      logger.error(
+        `Error occurred while constructing the customer query list ${err.message} with query ${JSON.stringify(
+          rootQuery,
+        )}`,
+      );
+      logger.error(`Error stack ${err.message}`);
+      return null;
+    }
+  }
+
   private async fetchSrsQueries(rootQueries: any) {
     const srsFolder = await this.findQueryFolderByName(rootQueries, 'srs');
     if (!srsFolder) {
@@ -735,55 +787,42 @@ export default class TicketsDataProvider {
     const { root: sysRsRoot, found: sysRsRootFound } = await this.getDocTypeRoot(rootQueries, 'sysrs');
     logger.debug(`[GetSharedQueries][sysrs] using ${sysRsRootFound ? 'dedicated folder' : 'root queries'}`);
 
-    const systemToCustomerFolderNames = [
-      'system to customer',
-      'system-to-customer',
-      'system customer',
-      'subsystem to system',
-      'customer to system',
-    ];
     const systemToSubsystemFolderNames = ['system to subsystem', 'system-to-subsystem', 'system subsystem'];
 
-    const systemRequirementsQueries = await this.fetchSystemRequirementQueries(sysRsRoot, [
-      ...systemToCustomerFolderNames,
-      ...systemToSubsystemFolderNames,
-    ]);
-
-    const systemToCustomerFolder = await this.findChildFolderByPossibleNames(
-      sysRsRoot,
-      systemToCustomerFolderNames,
-    );
-    const systemToSubsystemFolder = await this.findChildFolderByPossibleNames(
+    const systemRequirementsQueries = await this.fetchSystemRequirementQueries(
       sysRsRoot,
       systemToSubsystemFolderNames,
     );
 
-    const subsystemToSystemRequirementsQueries =
-      await this.fetchRequirementsTraceQueriesForFolder(systemToCustomerFolder);
+    const systemToSubsystemFolder = await this.findChildFolderByPossibleNames(
+      sysRsRoot,
+      systemToSubsystemFolderNames,
+    );
     const systemToSubsystemRequirementsQueries =
       await this.fetchRequirementsTraceQueriesForFolder(systemToSubsystemFolder);
 
-    // Customer/System requirements (traceability table) picker: only scan the dedicated
-    // System-to-Customer folder. If it doesn't exist in the tenant, return null
-    // rather than scanning the whole SysRS root, which would surface unrelated
-    // flat queries into the picker.
+    // Customer/System requirements (traceability table) picker: scan the entire
+    // dedicated SysRS folder for executable query nodes. The selected query
+    // defines the customer-side candidate set, so discovery does not infer
+    // "customer" semantics from WIQL. Scope is intentionally limited to the
+    // dedicated `sysrs` folder so unrelated queries from the Shared Queries root
+    // do not leak into the picker.
     let customerRequirementsQueries: any = null;
-    if (systemToCustomerFolder) {
-      customerRequirementsQueries = await this.fetchFlatUpstreamQueries(
-        systemToCustomerFolder,
-        [],
-        ['requirement'],
-      );
+    if (sysRsRootFound) {
+      customerRequirementsQueries = await this.fetchCustomerRequirementQueries(sysRsRoot);
     } else {
       logger.debug(
-        '[GetSharedQueries][sysrs] System-to-Customer folder not found; skipping customer-requirements picker',
+        '[GetSharedQueries][sysrs] dedicated sysrs folder not found; skipping customer-requirements picker',
       );
     }
 
     return {
       systemRequirementsQueries,
       customerRequirementsQueries,
-      subsystemToSystemRequirementsQueries,
+      // Legacy field retained for backward compatibility with callers/tests.
+      // The sub-system -> system trace table is out of scope for v0 and no
+      // longer sourced from a hardcoded "System to Customer" folder.
+      subsystemToSystemRequirementsQueries: null,
       systemToSubsystemRequirementsQueries,
     };
   }
@@ -2256,42 +2295,46 @@ export default class TicketsDataProvider {
   }
 
   async PopulateWorkItemsByIds(workItemsArray: any[] = [], projectName: string = ''): Promise<any[]> {
-    let url = `${this.orgUrl}${projectName}/_apis/wit/workitemsbatch`;
-    let res: any[] = [];
-    let divByMax = Math.floor(workItemsArray.length / 200);
-    let modulusByMax = workItemsArray.length % 200;
-    //iterating
-    for (let i = 0; i < divByMax; i++) {
-      let from = i * 200;
-      let to = (i + 1) * 200;
-      let currentIds = workItemsArray.slice(from, to);
-      try {
-        let subRes = await TFSServices.getItemContent(url, this.token, 'post', {
+    const baseUrl = `${this.orgUrl}${projectName}/_apis/wit/workitemsbatch`;
+    // On-prem Azure DevOps Server rejects this POST with HTTP 400 unless an
+    // api-version is explicitly set on the URL. Use the same fallback chain
+    // (7.1 -> 5.1 -> no version) the historical batch hydration already uses,
+    // so the helper stays compatible with ADO cloud and older on-prem tenants.
+    const postBatch = (currentIds: any[]) =>
+      this.withHistoricalApiVersionFallback('populate-workitems-batch', (apiVersion) =>
+        TFSServices.getItemContent(this.appendApiVersion(baseUrl, apiVersion), this.token, 'post', {
           $expand: 'Relations',
           ids: currentIds,
-        });
-        res = [...res, ...subRes.value];
+        }),
+      ).then(({ result }) => result);
+
+    const res: any[] = [];
+    const divByMax = Math.floor(workItemsArray.length / 200);
+    const modulusByMax = workItemsArray.length % 200;
+    for (let i = 0; i < divByMax; i++) {
+      const from = i * 200;
+      const to = (i + 1) * 200;
+      const currentIds = workItemsArray.slice(from, to);
+      try {
+        const subRes = await postBatch(currentIds);
+        res.push(...subRes.value);
       } catch (error) {
         logger.error(`error populating workitems array`);
         logger.error(JSON.stringify(error));
         return [];
       }
     }
-    //compliting the rimainder
     if (modulusByMax !== 0) {
       try {
-        let currentIds = workItemsArray.slice(workItemsArray.length - modulusByMax, workItemsArray.length);
-        let subRes = await TFSServices.getItemContent(url, this.token, 'post', {
-          $expand: 'Relations',
-          ids: currentIds,
-        });
-        res = [...res, ...subRes.value];
+        const currentIds = workItemsArray.slice(workItemsArray.length - modulusByMax, workItemsArray.length);
+        const subRes = await postBatch(currentIds);
+        res.push(...subRes.value);
       } catch (error) {
         logger.error(`error populating workitems array`);
         logger.error(JSON.stringify(error));
         return [];
       }
-    } //if
+    }
 
     return res;
   }

--- a/src/tests/modules/ticketsDataProvider.test.ts
+++ b/src/tests/modules/ticketsDataProvider.test.ts
@@ -153,11 +153,119 @@ describe('TicketsDataProvider', () => {
     });
   });
 
+  describe('fetchCustomerRequirementQueries', () => {
+    it('should return flat, tree, and oneHop query nodes without WIQL type filtering', async () => {
+      const root = {
+        id: 'root',
+        name: 'SYSRS',
+        isFolder: true,
+        hasChildren: true,
+        children: [
+          {
+            id: 'flat-query',
+            name: 'Flat Customer Pull',
+            isFolder: false,
+            hasChildren: false,
+            queryType: 'flat',
+            wiql: "SELECT * FROM WorkItems WHERE [System.WorkItemType] = 'Task'",
+            columns: [],
+            _links: { wiql: { href: 'flat-url' } },
+          },
+          {
+            id: 'tree-query',
+            name: 'Tree Customer Pull',
+            isFolder: false,
+            hasChildren: false,
+            queryType: 'tree',
+            wiql: "SELECT * FROM WorkItemLinks WHERE [System.Links.LinkType] = 'System.LinkTypes.Hierarchy-Forward'",
+            columns: [],
+            _links: { wiql: { href: 'tree-url' } },
+          },
+          {
+            id: 'onehop-query',
+            name: 'OneHop Customer Pull',
+            isFolder: false,
+            hasChildren: false,
+            queryType: 'oneHop',
+            wiql: "SELECT * FROM WorkItemLinks WHERE [System.Links.LinkType] = 'System.LinkTypes.Related'",
+            columns: [],
+            _links: { wiql: { href: 'onehop-url' } },
+          },
+          {
+            id: 'unsupported-query',
+            name: 'Unsupported',
+            isFolder: false,
+            hasChildren: false,
+            queryType: 'invalid',
+            _links: { wiql: { href: 'unsupported-url' } },
+          },
+        ],
+      };
+
+      const result = await (ticketsDataProvider as any).fetchCustomerRequirementQueries(root, []);
+
+      expect(result.systemRequirementsQueryTree.children.map((child: any) => child.queryType)).toEqual([
+        'flat',
+        'tree',
+        'oneHop',
+      ]);
+      expect(result.systemRequirementsQueryTree.children.map((child: any) => child.wiql.href)).toEqual([
+        'flat-url',
+        'tree-url',
+        'onehop-url',
+      ]);
+    });
+
+    it('should include system-to-subsystem queries because customer discovery has no folder exclusions', async () => {
+      const root = {
+        id: 'root',
+        name: 'SYSRS',
+        isFolder: true,
+        hasChildren: true,
+        children: [
+          {
+            id: 'excluded-folder',
+            name: 'System To Subsystem',
+            isFolder: true,
+            hasChildren: true,
+            children: [
+              {
+                id: 'system-to-subsystem-query',
+                name: 'System To Subsystem Query',
+                isFolder: false,
+                hasChildren: false,
+                queryType: 'tree',
+                _links: { wiql: { href: 'system-to-subsystem-url' } },
+              },
+            ],
+          },
+          {
+            id: 'included-query',
+            name: 'Included Query',
+            isFolder: false,
+            hasChildren: false,
+            queryType: 'oneHop',
+            _links: { wiql: { href: 'included-url' } },
+          },
+        ],
+      };
+
+      const result = await (ticketsDataProvider as any).fetchCustomerRequirementQueries(root);
+
+      expect(result.systemRequirementsQueryTree.children).toHaveLength(2);
+      expect(result.systemRequirementsQueryTree.children[0].children[0]).toEqual(
+        expect.objectContaining({ id: 'system-to-subsystem-query', queryType: 'tree' }),
+      );
+      expect(result.systemRequirementsQueryTree.children[1]).toEqual(
+        expect.objectContaining({ id: 'included-query', queryType: 'oneHop' }),
+      );
+    });
+  });
+
   describe('fetchSysRsQueries', () => {
-    it('should use sysrs root, exclude trace folders from system requirements and resolve both trace directions', async () => {
+    it('should scan the dedicated sysrs folder for customer queries regardless of query type', async () => {
       const rootQueries = { id: 'root' };
       const sysRsRoot = { id: 'sysrs-root', name: 'SYSRS' };
-      const subsystemToSystemFolder = { id: 'fwd-folder', name: 'System To Customer' };
       const systemToSubsystemFolder = { id: 'rev-folder', name: 'System To Subsystem' };
 
       const getDocTypeRootSpy = jest
@@ -166,56 +274,49 @@ describe('TicketsDataProvider', () => {
       const fetchSystemRequirementQueriesSpy = jest
         .spyOn(ticketsDataProvider as any, 'fetchSystemRequirementQueries')
         .mockResolvedValue({ systemRequirementsQueryTree: { id: 'system-tree' } });
-      const fetchFlatUpstreamQueriesSpy = jest
-        .spyOn(ticketsDataProvider as any, 'fetchFlatUpstreamQueries')
+      const fetchCustomerRequirementQueriesSpy = jest
+        .spyOn(ticketsDataProvider as any, 'fetchCustomerRequirementQueries')
         .mockResolvedValue({ systemRequirementsQueryTree: { id: 'customer-tree' } });
       const findChildFolderByPossibleNamesSpy = jest
         .spyOn(ticketsDataProvider as any, 'findChildFolderByPossibleNames')
-        .mockResolvedValueOnce(subsystemToSystemFolder)
         .mockResolvedValueOnce(systemToSubsystemFolder);
       const fetchRequirementsTraceQueriesForFolderSpy = jest
         .spyOn(ticketsDataProvider as any, 'fetchRequirementsTraceQueriesForFolder')
-        .mockResolvedValueOnce({ id: 'fwd-trace-tree' })
         .mockResolvedValueOnce({ id: 'rev-trace-tree' });
 
       const result = await (ticketsDataProvider as any).fetchSysRsQueries(rootQueries);
 
       expect(getDocTypeRootSpy).toHaveBeenCalledWith(rootQueries, 'sysrs');
+      // fetchSystemRequirementQueries only excludes the sub-system trace folder;
+      // the legacy System-to-Customer exclusion list is gone.
       expect(fetchSystemRequirementQueriesSpy).toHaveBeenCalledWith(sysRsRoot, [
-        'system to customer',
-        'system-to-customer',
-        'system customer',
-        'subsystem to system',
-        'customer to system',
         'system to subsystem',
         'system-to-subsystem',
         'system subsystem',
       ]);
 
-      expect(findChildFolderByPossibleNamesSpy).toHaveBeenNthCalledWith(
-        1,
-        sysRsRoot,
-        expect.arrayContaining(['system to customer', 'subsystem to system', 'customer to system']),
-      );
-      expect(findChildFolderByPossibleNamesSpy).toHaveBeenNthCalledWith(
-        2,
+      // Only one folder lookup remains (sub-system trace); no System-to-Customer lookup.
+      expect(findChildFolderByPossibleNamesSpy).toHaveBeenCalledTimes(1);
+      expect(findChildFolderByPossibleNamesSpy).toHaveBeenCalledWith(
         sysRsRoot,
         expect.arrayContaining(['system to subsystem', 'system-to-subsystem']),
       );
 
-      expect(fetchRequirementsTraceQueriesForFolderSpy).toHaveBeenNthCalledWith(1, subsystemToSystemFolder);
-      expect(fetchRequirementsTraceQueriesForFolderSpy).toHaveBeenNthCalledWith(2, systemToSubsystemFolder);
-      expect(fetchFlatUpstreamQueriesSpy).toHaveBeenCalledWith(subsystemToSystemFolder, [], ['requirement']);
+      expect(fetchRequirementsTraceQueriesForFolderSpy).toHaveBeenCalledTimes(1);
+      expect(fetchRequirementsTraceQueriesForFolderSpy).toHaveBeenCalledWith(systemToSubsystemFolder);
+
+      // Customer picker scans the whole sysRsRoot with no query/folder exclusions.
+      expect(fetchCustomerRequirementQueriesSpy).toHaveBeenCalledWith(sysRsRoot);
 
       expect(result).toEqual({
         systemRequirementsQueries: { systemRequirementsQueryTree: { id: 'system-tree' } },
         customerRequirementsQueries: { systemRequirementsQueryTree: { id: 'customer-tree' } },
-        subsystemToSystemRequirementsQueries: { id: 'fwd-trace-tree' },
+        subsystemToSystemRequirementsQueries: null,
         systemToSubsystemRequirementsQueries: { id: 'rev-trace-tree' },
       });
     });
 
-    it('should return null customer/trace trees when trace folders are missing (no sysRsRoot fallback scan)', async () => {
+    it('should return null customer/trace trees when the dedicated sysrs folder is missing (no fallback scan)', async () => {
       const rootQueries = { id: 'root' };
 
       jest
@@ -224,34 +325,26 @@ describe('TicketsDataProvider', () => {
       const fetchSystemRequirementQueriesSpy = jest
         .spyOn(ticketsDataProvider as any, 'fetchSystemRequirementQueries')
         .mockResolvedValue({ systemRequirementsQueryTree: { id: 'system-tree' } });
-      const fetchFlatUpstreamQueriesSpy = jest
-        .spyOn(ticketsDataProvider as any, 'fetchFlatUpstreamQueries')
+      const fetchCustomerRequirementQueriesSpy = jest
+        .spyOn(ticketsDataProvider as any, 'fetchCustomerRequirementQueries')
         .mockResolvedValue({ systemRequirementsQueryTree: { id: 'should-not-be-used' } });
-      jest
-        .spyOn(ticketsDataProvider as any, 'findChildFolderByPossibleNames')
-        .mockResolvedValueOnce(null)
-        .mockResolvedValueOnce(null);
+      jest.spyOn(ticketsDataProvider as any, 'findChildFolderByPossibleNames').mockResolvedValueOnce(null);
       const fetchRequirementsTraceQueriesForFolderSpy = jest
         .spyOn(ticketsDataProvider as any, 'fetchRequirementsTraceQueriesForFolder')
-        .mockResolvedValueOnce(null)
         .mockResolvedValueOnce(null);
 
       const result = await (ticketsDataProvider as any).fetchSysRsQueries(rootQueries);
 
       expect(fetchSystemRequirementQueriesSpy).toHaveBeenCalledWith(rootQueries, [
-        'system to customer',
-        'system-to-customer',
-        'system customer',
-        'subsystem to system',
-        'customer to system',
         'system to subsystem',
         'system-to-subsystem',
         'system subsystem',
       ]);
-      expect(fetchRequirementsTraceQueriesForFolderSpy).toHaveBeenNthCalledWith(1, null);
-      expect(fetchRequirementsTraceQueriesForFolderSpy).toHaveBeenNthCalledWith(2, null);
-      // No fallback scan of sysRsRoot when the System-to-Customer folder is absent.
-      expect(fetchFlatUpstreamQueriesSpy).not.toHaveBeenCalled();
+      expect(fetchRequirementsTraceQueriesForFolderSpy).toHaveBeenCalledTimes(1);
+      expect(fetchRequirementsTraceQueriesForFolderSpy).toHaveBeenCalledWith(null);
+      // No fallback scan when the dedicated sysrs folder is absent — otherwise
+      // unrelated flat queries from the Shared Queries root would leak in.
+      expect(fetchCustomerRequirementQueriesSpy).not.toHaveBeenCalled();
       expect(result).toEqual({
         systemRequirementsQueries: { systemRequirementsQueryTree: { id: 'system-tree' } },
         customerRequirementsQueries: null,
@@ -1434,6 +1527,46 @@ describe('TicketsDataProvider', () => {
 
       // Assert
       expect(result).toBeDefined();
+    });
+
+    // Regression: WI_DEFAULT_FIELDS must include System.WorkItemType so that
+    // downstream Requirement-type filters (e.g. the customer-coverage table)
+    // do not drop every row because workItemType resolves to empty string.
+    it('should request System.WorkItemType in default fields for flat queries and expose workItemType on parsed items', async () => {
+      const mockWiqlHref = 'https://example.com/wiql';
+      const mockQueryResult = {
+        queryType: 'flat',
+        workItems: [{ id: 42, url: 'https://example.com/wi/42' }],
+      };
+      const mockWiResponse = {
+        fields: {
+          'System.Title': 'Customer Requirement',
+          'System.WorkItemType': 'Requirement',
+          'System.Description': 'Desc',
+        },
+        _links: { html: { href: 'https://example.com/wi/42' } },
+      };
+
+      (TFSServices.getItemContent as jest.Mock)
+        .mockResolvedValueOnce(mockQueryResult)
+        .mockResolvedValueOnce(mockWiResponse);
+
+      const result: any = await ticketsDataProvider.GetQueryResultsFromWiql(
+        mockWiqlHref,
+        false,
+        new Map<number, Set<any>>(),
+      );
+
+      // The per-item fetch URL must request System.WorkItemType.
+      const perItemCall = (TFSServices.getItemContent as jest.Mock).mock.calls.find(
+        (call: any[]) => typeof call[0] === 'string' && call[0].startsWith('https://example.com/wi/42'),
+      );
+      expect(perItemCall).toBeDefined();
+      expect(perItemCall[0]).toContain('System.WorkItemType');
+
+      // The parsed item must expose workItemType so downstream filters work.
+      expect(Array.isArray(result)).toBe(true);
+      expect(result[0]).toMatchObject({ id: 42, workItemType: 'Requirement' });
     });
 
     it('should return undefined when queryType is not supported', async () => {


### PR DESCRIPTION
Allow SysRS customer requirement discovery to return executable query metadata for flat, tree, and one-hop ADO queries instead of limiting the customer picker to flat queries only.

The selected customer query now defines the candidate set for Chapter 6 traceability. The provider does not inspect WIQL contents, infer customer semantics, or require Requirement/customer markers during discovery.

Changes:
- add customer-specific query discovery for the SysRS customer scope
- return flat, tree, and one-hop query metadata nodes
- keep returned data as metadata only, not executed work items
- preserve folder-absent behavior with customerRequirementsQueries null
- keep existing flat-only upstream helper behavior for other callers
- update tests for unrestricted customer discovery and absent folders