### PR TITLE
fix(svd): harden pipeline and release auto-discovery

### DIFF
--- a/src/helpers/tfs.ts
+++ b/src/helpers/tfs.ts
@@ -131,7 +131,7 @@ export class TFSServices {
       headers: customHeaders,
       method: requestMethod,
       data: data,
-      timeout: requestMethod.toLocaleLowerCase() === 'get' ? 10000 : undefined, // More reasonable timeout
+      timeout: requestMethod.toLocaleLowerCase() === 'get' ? 30000 : undefined,
     };
 
     this.applyAuth(config, pat);
@@ -157,7 +157,7 @@ export class TFSServices {
       headers: customHeaders,
       method: requestMethod,
       data: data,
-      timeout: requestMethod.toLocaleLowerCase() === 'get' ? 10000 : undefined,
+      timeout: requestMethod.toLocaleLowerCase() === 'get' ? 30000 : undefined,
     };
 
     this.applyAuth(config, pat);
@@ -218,8 +218,8 @@ export class TFSServices {
     responseProcessor: (response: any) => any
   ): Promise<any> {
     let attempts = 0;
-    const maxAttempts = 3;
     const baseDelay = 500; // Start with 500ms delay
+    const maxAttempts = 3;
 
     while (true) {
       try {
@@ -261,7 +261,12 @@ export class TFSServices {
    */
   private static isRetryableError(error: any): boolean {
     // Network errors
-    if (error.code === 'ECONNRESET' || error.code === 'ETIMEDOUT' || error.message.includes('timeout')) {
+    if (
+      error.code === 'ECONNRESET' ||
+      error.code === 'ETIMEDOUT' ||
+      error.code === 'ENOTFOUND' ||
+      error.message.includes('timeout')
+    ) {
       return true;
     }
 
@@ -283,7 +288,7 @@ export class TFSServices {
    */
   private static logDetailedError(error: any, url: string): void {
     if (error.response) {
-      logger.error(`Error for ${url}: ${error.message}`);
+      logger.error(`Error for ${url} - ${error.message}`);
       logger.error(`Status: ${error.response.status}`);
 
       if (error.response.data) {
@@ -296,7 +301,7 @@ export class TFSServices {
         }
       }
     } else {
-      logger.error(`Error for ${url}: ${error.message}`);
+      logger.error(`Error for ${url} - ${error.message}`);
     }
   }
 

--- a/src/modules/PipelinesDataProvider.ts
+++ b/src/modules/PipelinesDataProvider.ts
@@ -3,6 +3,13 @@ import { TFSServices } from '../helpers/tfs';
 
 import logger from '../utils/logger';
 import GitDataProvider from './GitDataProvider';
+const pLimit = require('p-limit');
+const MAX_DISCOVERY_PAGES = 50;
+
+type PreviousDiscoveryResult =
+  | { status: 'found'; id: number }
+  | { status: 'not_found' }
+  | { status: 'failed'; error: unknown };
 
 export default class PipelinesDataProvider {
   orgUrl: string = '';
@@ -14,6 +21,20 @@ export default class PipelinesDataProvider {
     this.token = token;
   }
 
+  /**
+   * Resolves the previous pipeline run used as the source side of an SVD pipeline range.
+   *
+   * For regular pipeline ranges, the Builds API is used first because it supports paging,
+   * completed/succeeded filters, and branch filtering. Stage-specific discovery keeps the
+   * older Pipelines Runs path because stage status must be checked from run details.
+   *
+   * @param teamProject Azure DevOps project name.
+   * @param pipelineId Pipeline/build definition id.
+   * @param toPipelineRunId Target run/build id. Candidates must be older than this id.
+   * @param targetPipeline Full target pipeline run details, used for repository/branch matching.
+   * @param searchPrevPipelineFromDifferentCommit When true, skip candidates from the same commit.
+   * @param fromStage Optional stage name. When set, only previous runs with this successful stage match.
+   */
   public async findPreviousPipeline(
     teamProject: string,
     pipelineId: string,
@@ -22,8 +43,21 @@ export default class PipelinesDataProvider {
     searchPrevPipelineFromDifferentCommit: boolean,
     fromStage: string = ''
   ) {
+    if (!fromStage) {
+      const previousBuildId = await this.findPreviousSuccessfulBuild(
+        teamProject,
+        pipelineId,
+        toPipelineRunId,
+        targetPipeline,
+        searchPrevPipelineFromDifferentCommit
+      );
+      if (previousBuildId) {
+        return previousBuildId;
+      }
+    }
+
     const pipelineRuns = await this.GetPipelineRunHistory(teamProject, pipelineId);
-    if (!pipelineRuns.value) {
+    if (!pipelineRuns?.value) {
       return undefined;
     }
 
@@ -46,6 +80,338 @@ export default class PipelinesDataProvider {
       }
     }
     return undefined;
+  }
+
+  /**
+   * Finds the previous successful completed build for a definition.
+   *
+   * Discovery prefers the target run's branch first. If no same-branch candidate exists, it
+   * falls back to the same repository on any branch so auto-discovery can still work for
+   * sparse branches or customer histories where the previous success is on another branch.
+   *
+   * @returns Previous build id, or undefined when no valid candidate is found.
+   */
+  public async findPreviousSuccessfulBuild(
+    teamProject: string,
+    definitionId: string,
+    toBuildId: number,
+    targetPipeline: any,
+    searchPrevPipelineFromDifferentCommit: boolean
+  ): Promise<number | undefined> {
+    const targetRepo = this.getPrimaryPipelineRepository(targetPipeline);
+    const targetBranch = this.normalizeBranchName(targetRepo?.refName);
+
+    if (targetBranch) {
+      const sameBranchResult = await this.findPreviousSuccessfulBuildPage(
+        teamProject,
+        definitionId,
+        toBuildId,
+        targetPipeline,
+        searchPrevPipelineFromDifferentCommit,
+        targetBranch
+      );
+      if (sameBranchResult.status === 'failed') {
+        throw sameBranchResult.error;
+      }
+      if (sameBranchResult.status === 'found') {
+        return sameBranchResult.id;
+      }
+    }
+
+    const anyBranchResult = await this.findPreviousSuccessfulBuildPage(
+      teamProject,
+      definitionId,
+      toBuildId,
+      targetPipeline,
+      searchPrevPipelineFromDifferentCommit
+    );
+    if (anyBranchResult.status === 'failed') {
+      throw anyBranchResult.error;
+    }
+    return anyBranchResult.status === 'found' ? anyBranchResult.id : undefined;
+  }
+
+  /**
+   * Pages the Builds API until a valid previous successful build is found.
+   *
+   * The API query already asks for completed/succeeded builds ordered by finish time, but
+   * candidates are validated locally as well to protect callers from incomplete API data,
+   * mocks, or future response-shape differences.
+   */
+  private async findPreviousSuccessfulBuildPage(
+    teamProject: string,
+    definitionId: string,
+    toBuildId: number,
+    targetPipeline: any,
+    searchPrevPipelineFromDifferentCommit: boolean,
+    branchName?: string
+  ): Promise<PreviousDiscoveryResult> {
+    const targetRepo = this.getPrimaryPipelineRepository(targetPipeline);
+    let continuationToken: string | undefined = undefined;
+    let pageCount = 0;
+    do {
+      let url = `${this.orgUrl}${teamProject}/_apis/build/builds?definitions=${encodeURIComponent(
+        String(definitionId)
+      )}&resultFilter=succeeded&statusFilter=completed&queryOrder=finishTimeDescending&$top=200&api-version=6.0`;
+      if (branchName) {
+        url += `&branchName=${encodeURIComponent(branchName)}`;
+      }
+      if (continuationToken) {
+        url += `&continuationToken=${encodeURIComponent(continuationToken)}`;
+      }
+
+      try {
+        const { data, headers } = await TFSServices.getItemContentWithHeaders(
+          url,
+          this.token,
+          'get',
+          null,
+          null
+        );
+        pageCount++;
+        const builds: any[] = data?.value || [];
+        const match = builds.find((build: any) =>
+          this.isMatchingPreviousBuild(
+            build,
+            targetRepo,
+            toBuildId,
+            searchPrevPipelineFromDifferentCommit,
+            branchName
+          )
+        );
+        if (match?.id) {
+          return { status: 'found', id: Number(match.id) };
+        }
+        continuationToken = this.getContinuationToken(headers);
+        if (continuationToken && pageCount >= MAX_DISCOVERY_PAGES) {
+          return {
+            status: 'failed',
+            error: new Error(`Pipeline discovery exceeded ${MAX_DISCOVERY_PAGES} pages`),
+          };
+        }
+      } catch (err: unknown) {
+        logger.warn(`Could not fetch previous successful builds: ${this.getErrorMessage(err)}`);
+        return { status: 'failed', error: err };
+      }
+    } while (continuationToken);
+
+    return { status: 'not_found' };
+  }
+
+  private getContinuationToken(headers: any): string | undefined {
+    return headers?.['x-ms-continuationtoken'] || headers?.['x-ms-continuation-token'] || undefined;
+  }
+
+  /**
+   * Extracts the primary repository from a pipeline run details response.
+   *
+   * Newer YAML runs expose repository resources as an array with a `self` entry, while some
+   * designer/classic pipeline responses expose the repository under `__designer_repo`.
+   */
+  private getPrimaryPipelineRepository(pipeline: any): any {
+    const repositories = pipeline?.resources?.repositories;
+    if (!repositories) return undefined;
+    return repositories[0]?.self || repositories.__designer_repo;
+  }
+
+  /**
+   * Validates a Builds API candidate against the target run.
+   *
+   * A candidate must be older than the target, completed successfully, from the same
+   * repository, and optionally from the required branch. When the caller asks for a
+   * different commit, candidates with the same source version are excluded.
+   */
+  private isMatchingPreviousBuild(
+    build: any,
+    targetRepo: any,
+    toBuildId: number,
+    searchPrevPipelineFromDifferentCommit: boolean,
+    requiredBranch?: string
+  ): boolean {
+    const buildId = Number(build?.id);
+    if (!Number.isFinite(buildId) || buildId >= toBuildId) return false;
+    if (build?.status && build.status !== 'completed') return false;
+    if (build?.result && build.result !== 'succeeded') return false;
+
+    const buildRepoId = build?.repository?.id;
+    const targetRepoId = targetRepo?.repository?.id;
+    if (!buildRepoId || !targetRepoId || buildRepoId !== targetRepoId) return false;
+
+    if (requiredBranch && build?.sourceBranch !== requiredBranch) return false;
+
+    if (build?.sourceVersion && targetRepo?.version && build.sourceVersion === targetRepo.version) {
+      return !searchPrevPipelineFromDifferentCommit;
+    }
+
+    return true;
+  }
+
+  /**
+   * Finds the previous successful release/deployment for an SVD release range.
+   *
+   * Release discovery pages the Release List API and expands environments so candidates can
+   * be validated by deployment status. A matching release must be older than the target,
+   * active, and have at least one succeeded environment.
+   *
+   * @returns Previous release id, or undefined when no valid candidate is found.
+   */
+  public async findPreviousSuccessfulRelease(
+    projectName: string,
+    definitionId: string,
+    toReleaseId: number
+  ): Promise<number | undefined> {
+    let result = await this.findSuccessfulReleasePage(
+      projectName,
+      definitionId,
+      '7.1',
+      (release) => this.isPreviousSuccessfulRelease(release, toReleaseId),
+      'previous'
+    );
+    if (result.status === 'failed' && this.isUnsupportedApiVersionError(result.error)) {
+      result = await this.findSuccessfulReleasePage(
+        projectName,
+        definitionId,
+        '6.0',
+        (release) => this.isPreviousSuccessfulRelease(release, toReleaseId),
+        'previous'
+      );
+    }
+    if (result.status === 'failed') {
+      throw result.error;
+    }
+    return result.status === 'found' ? result.id : undefined;
+  }
+
+  /**
+   * Finds the latest successful release/deployment for an SVD release range.
+   *
+   * Used when the release template omits `toReleaseId`. The same candidate rule is used as
+   * previous-release discovery: active release with at least one succeeded environment.
+   *
+   * @returns Latest release id, or undefined when no valid candidate is found.
+   */
+  public async findLatestSuccessfulRelease(
+    projectName: string,
+    definitionId: string
+  ): Promise<number | undefined> {
+    let result = await this.findSuccessfulReleasePage(
+      projectName,
+      definitionId,
+      '7.1',
+      (release) => this.isSuccessfulRelease(release),
+      'latest'
+    );
+    if (result.status === 'failed' && this.isUnsupportedApiVersionError(result.error)) {
+      result = await this.findSuccessfulReleasePage(
+        projectName,
+        definitionId,
+        '6.0',
+        (release) => this.isSuccessfulRelease(release),
+        'latest'
+      );
+    }
+    if (result.status === 'failed') {
+      throw result.error;
+    }
+    return result.status === 'found' ? result.id : undefined;
+  }
+
+  private async findSuccessfulReleasePage(
+    projectName: string,
+    definitionId: string,
+    apiVersion: string,
+    isMatch: (release: any) => boolean,
+    discoveryLabel: 'previous' | 'latest'
+  ): Promise<PreviousDiscoveryResult> {
+    let baseUrl: string = `${this.orgUrl}${projectName}/_apis/release/releases?definitionId=${encodeURIComponent(
+      String(definitionId)
+    )}&queryOrder=descending&$top=200&$expand=environments&api-version=${apiVersion}`;
+    if (baseUrl.startsWith('https://dev.azure.com')) {
+      baseUrl = baseUrl.replace('https://dev.azure.com', 'https://vsrm.dev.azure.com');
+    }
+
+    let continuationToken: string | undefined = undefined;
+    let pageCount = 0;
+    do {
+      let url = baseUrl;
+      if (continuationToken) {
+        url += `&continuationToken=${encodeURIComponent(continuationToken)}`;
+      }
+
+      try {
+        const { data, headers } = await TFSServices.getItemContentWithHeaders(
+          url,
+          this.token,
+          'get',
+          null,
+          null
+        );
+        pageCount++;
+        const releases: any[] = data?.value || [];
+        const match = releases.find(isMatch);
+        if (match?.id) {
+          return { status: 'found', id: Number(match.id) };
+        }
+        continuationToken = this.getContinuationToken(headers);
+        if (continuationToken && pageCount >= MAX_DISCOVERY_PAGES) {
+          return {
+            status: 'failed',
+            error: new Error(`Release discovery exceeded ${MAX_DISCOVERY_PAGES} pages`),
+          };
+        }
+      } catch (err: unknown) {
+        logger.warn(`Could not fetch ${discoveryLabel} successful releases: ${this.getErrorMessage(err)}`);
+        return { status: 'failed', error: err };
+      }
+    } while (continuationToken);
+
+    return { status: 'not_found' };
+  }
+
+  private isUnsupportedApiVersionError(err: unknown): boolean {
+    const error = err as any;
+    const responseData = error?.response?.data;
+    const message = [
+      error?.message,
+      responseData?.message,
+      typeof responseData === 'string' ? responseData : JSON.stringify(responseData || ''),
+    ]
+      .join(' ')
+      .toLowerCase();
+    return (
+      message.includes('api-version') &&
+      (message.includes('unsupported') ||
+        message.includes('not support') ||
+        message.includes('not supported'))
+    );
+  }
+
+  private getErrorMessage(err: unknown): string {
+    return err instanceof Error ? err.message : String(err);
+  }
+
+  /**
+   * Validates a release candidate for auto-discovery.
+   *
+   * A release is considered successful for this SVD range purpose when at least one
+   * deployment environment succeeded. This mirrors the existing release artifact flow,
+   * where a release may contain multiple environments but still provide usable artifacts.
+   */
+  private isPreviousSuccessfulRelease(release: any, toReleaseId: number): boolean {
+    const releaseId = Number(release?.id);
+    if (!Number.isFinite(releaseId) || releaseId >= toReleaseId) return false;
+    return this.isSuccessfulRelease(release);
+  }
+
+  private isSuccessfulRelease(release: any): boolean {
+    const releaseId = Number(release?.id);
+    if (!Number.isFinite(releaseId)) return false;
+    if (release?.status && String(release.status).toLowerCase() !== 'active') return false;
+
+    const environments = Array.isArray(release?.environments) ? release.environments : [];
+    return environments.some((environment: any) => {
+      return String(environment?.status || '').toLowerCase() === 'succeeded';
+    });
   }
 
   /**
@@ -483,8 +849,9 @@ export default class PipelinesDataProvider {
       `getPipelineResourcePipelinesFromObject: resolving ${pipelineEntries.length} pipeline resources`
     );
 
+    const concurrencyLimit = pLimit(8);
     await Promise.all(
-      pipelineEntries.map(async ([resourcePipelineAlias, resource]) => {
+      pipelineEntries.map(([resourcePipelineAlias, resource]) => concurrencyLimit(async () => {
         const resourcePipelineObj = (resource as any)?.pipeline;
         const pipelineIdCandidate = Number(resourcePipelineObj?.id);
 
@@ -596,7 +963,7 @@ export default class PipelinesDataProvider {
           const key = `${resourcePipelineToAdd.teamProject}:${resourcePipelineToAdd.definitionId}:${resourcePipelineToAdd.buildId}:${resourcePipelineToAdd.name}`;
           if (!resourcePipelinesByKey.has(key)) resourcePipelinesByKey.set(key, resourcePipelineToAdd);
         }
-      })
+      }))
     );
     return [...resourcePipelinesByKey.values()];
   }
@@ -757,6 +1124,12 @@ export default class PipelinesDataProvider {
     }
   }
 
+  /**
+   * Fetches the first page of release history for a definition.
+   *
+   * Kept for backward compatibility with existing consumers. New range/discovery flows
+   * should prefer GetAllReleaseHistory when full release history is required.
+   */
   async GetReleaseHistory(projectName: string, definitionId: string) {
     let url: string = `${this.orgUrl}${projectName}/_apis/release/releases?definitionId=${definitionId}&$top=200`;
     if (url.startsWith('https://dev.azure.com')) {
@@ -767,9 +1140,16 @@ export default class PipelinesDataProvider {
   }
 
   /**
-   * Fetch all releases for a definition using continuation tokens.
+   * Fetches all releases for a definition using continuation tokens.
+   *
+   * This is used by SVD release range handling because the requested from/to releases may be
+   * older than the first page returned by Azure DevOps.
+   *
+   * @param range When provided, pagination stops as soon as both fromId and toId are present in
+   *   the accumulated results. ADO returns releases in descending id order, so once the smallest
+   *   id seen is <= the lower requested id both endpoints are guaranteed to be loaded.
    */
-  async GetAllReleaseHistory(projectName: string, definitionId: string) {
+  async GetAllReleaseHistory(projectName: string, definitionId: string, range?: { fromId: number; toId: number }) {
     let baseUrl: string = `${this.orgUrl}${projectName}/_apis/release/releases?definitionId=${definitionId}&api-version=6.0`;
     if (baseUrl.startsWith('https://dev.azure.com')) {
       baseUrl = baseUrl.replace('https://dev.azure.com', 'https://vsrm.dev.azure.com');
@@ -793,14 +1173,25 @@ export default class PipelinesDataProvider {
         );
         const { value = [] } = data || {};
         all.push(...value);
-        // Azure DevOps returns continuation token header for next page
-        continuationToken =
-          headers?.['x-ms-continuationtoken'] || headers?.['x-ms-continuation-token'] || undefined;
         page++;
         logger.debug(`GetAllReleaseHistory: fetched page ${page}, cumulative ${all.length} releases`);
+
+        // Stop-early: once the smallest id in the accumulated list is <= the lower
+        // requested id, both endpoints of the range are present.
+        if (range && all.length > 0) {
+          const lowerBound = Math.min(range.fromId, range.toId);
+          const minId = Math.min(...all.map((r: any) => Number(r.id)));
+          if (minId <= lowerBound) {
+            logger.debug(`GetAllReleaseHistory: stop-early at page ${page} (minId=${minId} <= lowerBound=${lowerBound})`);
+            break;
+          }
+        }
+
+        // Azure DevOps returns continuation token header for next page
+        continuationToken = this.getContinuationToken(headers);
       } catch (err: any) {
         logger.error(`GetAllReleaseHistory failed: ${err.message}`);
-        break;
+        throw err;
       }
     } while (continuationToken);
 

--- a/src/modules/TicketsDataProvider.ts
+++ b/src/modules/TicketsDataProvider.ts
@@ -3189,7 +3189,8 @@ export default class TicketsDataProvider {
 
   public async GetWorkItemTypeList(project: string) {
     try {
-      let url = `${this.orgUrl}${project}/_apis/wit/workitemtypes?api-version=5.1`;
+      const query = new URLSearchParams({ 'api-version': '5.1' }).toString();
+      let url = `${this.orgUrl}${encodeURIComponent(project)}/_apis/wit/workitemtypes?${query}`;
       const { value: workItemTypes } = await TFSServices.getItemContent(url, this.token);
       const workItemTypesWithIcons = await Promise.all(
         workItemTypes.map(async (workItemType: any) => {

--- a/src/tests/helpers/tfs.test.ts
+++ b/src/tests/helpers/tfs.test.ts
@@ -21,6 +21,7 @@ describe('TFSServices', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockAxiosInstance.request.mockReset();
     // Mock Math.random to return a predictable value for tests with retry
     Math.random = jest.fn().mockReturnValue(0.5);
   });
@@ -191,7 +192,7 @@ describe('TFSServices', () => {
           url: url.replace(/ /g, '%20'),
           method: 'get',
           auth: { username: '', password: pat },
-          timeout: 10000, // Verify the actual timeout value is 10000ms
+          timeout: 30000,
         })
       );
     });
@@ -228,7 +229,7 @@ describe('TFSServices', () => {
       timeoutError.name = 'TimeoutError';
       (timeoutError as any).code = 'ECONNABORTED';
 
-      // Configure mock to simulate timeout (will retry 3 times by default)
+      // Timeout errors should get the standard retry budget.
       mockAxiosInstance.request
         .mockRejectedValueOnce(timeoutError)
         .mockRejectedValueOnce(timeoutError)
@@ -290,7 +291,7 @@ describe('TFSServices', () => {
 
       // Act & Assert
       await expect(TFSServices.getItemContent(url, pat)).rejects.toThrow('ENOTFOUND');
-      expect(mockAxiosInstance.request).toHaveBeenCalledTimes(2); // Should retry DNS failures too
+      expect(mockAxiosInstance.request).toHaveBeenCalledTimes(3); // Initial + 2 retries
     });
 
     it('should handle spaces in URL by replacing them with %20', async () => {

--- a/src/tests/modules/pipelineDataProvider.test.ts
+++ b/src/tests/modules/pipelineDataProvider.test.ts
@@ -581,18 +581,309 @@ describe('PipelinesDataProvider', () => {
       expect(result.value).toEqual([{ id: 1 }]);
     });
 
-    it('should handle errors during pagination', async () => {
+    it('should continue paging for reversed release ranges until the lower release id is loaded', async () => {
+      const projectName = 'project1';
+      const definitionId = '456';
+
+      (TFSServices.getItemContentWithHeaders as jest.Mock)
+        .mockResolvedValueOnce({
+          data: { value: [{ id: 20 }, { id: 19 }] },
+          headers: { 'x-ms-continuationtoken': 'page-2' },
+        })
+        .mockResolvedValueOnce({
+          data: { value: [{ id: 14 }, { id: 13 }] },
+          headers: {},
+        });
+
+      const result = await pipelinesDataProvider.GetAllReleaseHistory(projectName, definitionId, {
+        fromId: 20,
+        toId: 14,
+      });
+
+      expect(result.value.map((r: any) => r.id)).toEqual([20, 19, 14, 13]);
+      expect(TFSServices.getItemContentWithHeaders).toHaveBeenCalledTimes(2);
+    });
+
+    it('should throw when release history pagination fails', async () => {
       // Arrange
       const projectName = 'project1';
       const definitionId = '456';
       (TFSServices.getItemContentWithHeaders as jest.Mock).mockRejectedValueOnce(new Error('API Error'));
 
-      // Act
-      const result = await pipelinesDataProvider.GetAllReleaseHistory(projectName, definitionId);
-
       // Assert
-      expect(result).toEqual({ count: 0, value: [] });
+      await expect(pipelinesDataProvider.GetAllReleaseHistory(projectName, definitionId)).rejects.toThrow(
+        'API Error'
+      );
       expect(logger.error).toHaveBeenCalled();
+    });
+  });
+
+  describe('findPreviousSuccessfulRelease', () => {
+    const releaseCandidate = (id: number, status = 'succeeded') => ({
+      id,
+      status: 'active',
+      environments: [{ status }],
+      releaseDefinition: { id: 456 },
+    });
+
+    it('should find previous successful release on a later Release API page', async () => {
+      const projectName = 'project1';
+      const definitionId = '456';
+
+      (TFSServices.getItemContentWithHeaders as jest.Mock)
+        .mockResolvedValueOnce({
+          data: { value: [] },
+          headers: { 'x-ms-continuationtoken': 'next-page' },
+        })
+        .mockResolvedValueOnce({
+          data: { value: [releaseCandidate(80)] },
+          headers: {},
+        });
+
+      const result = await pipelinesDataProvider.findPreviousSuccessfulRelease(
+        projectName,
+        definitionId,
+        100
+      );
+
+      expect(result).toBe(80);
+      expect(TFSServices.getItemContentWithHeaders).toHaveBeenCalledWith(
+        expect.stringContaining('continuationToken=next-page'),
+        mockToken,
+        'get',
+        null,
+        null
+      );
+    });
+
+    it('should query release history with expanded environments and ignore non-successful releases', async () => {
+      const projectName = 'project1';
+      const definitionId = '456';
+
+      (TFSServices.getItemContentWithHeaders as jest.Mock).mockResolvedValueOnce({
+        data: {
+          value: [
+            releaseCandidate(99, 'failed'),
+            releaseCandidate(98, 'rejected'),
+            releaseCandidate(97, 'succeeded'),
+          ],
+        },
+        headers: {},
+      });
+
+      const result = await pipelinesDataProvider.findPreviousSuccessfulRelease(
+        projectName,
+        definitionId,
+        100
+      );
+
+      const url = (TFSServices.getItemContentWithHeaders as jest.Mock).mock.calls[0][0];
+      expect(url).toContain(`definitionId=${definitionId}`);
+      expect(url).toContain('queryOrder=descending');
+      expect(url).toContain('$top=200');
+      expect(url).toContain('$expand=environments');
+      expect(result).toBe(97);
+    });
+
+    it('should retry release discovery with api-version 6.0 when 7.1 is unsupported', async () => {
+      const unsupportedError: any = new Error('The requested resource does not support api-version 7.1');
+      unsupportedError.response = { status: 404 };
+
+      (TFSServices.getItemContentWithHeaders as jest.Mock)
+        .mockRejectedValueOnce(unsupportedError)
+        .mockResolvedValueOnce({
+          data: { value: [releaseCandidate(90)] },
+          headers: {},
+        });
+
+      const result = await pipelinesDataProvider.findPreviousSuccessfulRelease('project1', '456', 100);
+
+      expect(result).toBe(90);
+      expect((TFSServices.getItemContentWithHeaders as jest.Mock).mock.calls[0][0]).toContain(
+        'api-version=7.1'
+      );
+      expect((TFSServices.getItemContentWithHeaders as jest.Mock).mock.calls[1][0]).toContain(
+        'api-version=6.0'
+      );
+    });
+
+    it('should retry release discovery when unsupported api-version is reported in Axios response data', async () => {
+      const unsupportedError: any = new Error('Request failed with status code 404');
+      unsupportedError.response = {
+        status: 404,
+        data: { message: 'The requested resource does not support api-version 7.1' },
+      };
+
+      (TFSServices.getItemContentWithHeaders as jest.Mock)
+        .mockRejectedValueOnce(unsupportedError)
+        .mockResolvedValueOnce({
+          data: { value: [releaseCandidate(89)] },
+          headers: {},
+        });
+
+      const result = await pipelinesDataProvider.findPreviousSuccessfulRelease('project1', '456', 100);
+
+      expect(result).toBe(89);
+      expect((TFSServices.getItemContentWithHeaders as jest.Mock).mock.calls[1][0]).toContain(
+        'api-version=6.0'
+      );
+    });
+
+    it('should not retry api-version 6.0 for ordinary invalid release definition errors', async () => {
+      const invalidDefinitionError: any = new Error('Release definition 456 was not found');
+      invalidDefinitionError.response = { status: 404 };
+      (TFSServices.getItemContentWithHeaders as jest.Mock).mockRejectedValueOnce(invalidDefinitionError);
+
+      await expect(
+        pipelinesDataProvider.findPreviousSuccessfulRelease('project1', '456', 100)
+      ).rejects.toThrow('Release definition 456 was not found');
+
+      expect(TFSServices.getItemContentWithHeaders).toHaveBeenCalledTimes(1);
+      expect((TFSServices.getItemContentWithHeaders as jest.Mock).mock.calls[0][0]).toContain(
+        'api-version=7.1'
+      );
+    });
+
+    it('should throw release discovery permission errors without retrying api-version 6.0', async () => {
+      const permissionError: any = new Error('Forbidden');
+      permissionError.response = { status: 403 };
+      (TFSServices.getItemContentWithHeaders as jest.Mock).mockRejectedValueOnce(permissionError);
+
+      await expect(
+        pipelinesDataProvider.findPreviousSuccessfulRelease('project1', '456', 100)
+      ).rejects.toThrow('Forbidden');
+
+      expect(TFSServices.getItemContentWithHeaders).toHaveBeenCalledTimes(1);
+      expect((TFSServices.getItemContentWithHeaders as jest.Mock).mock.calls[0][0]).toContain(
+        'api-version=7.1'
+      );
+    });
+
+    it('should throw when a later release discovery page fails', async () => {
+      (TFSServices.getItemContentWithHeaders as jest.Mock)
+        .mockResolvedValueOnce({
+          data: { value: [] },
+          headers: { 'x-ms-continuationtoken': 'next-page' },
+        })
+        .mockRejectedValueOnce(new Error('page failed'));
+
+      await expect(
+        pipelinesDataProvider.findPreviousSuccessfulRelease('project1', '456', 100)
+      ).rejects.toThrow('page failed');
+    });
+
+    it('should throw when previous release discovery exceeds the defensive page limit', async () => {
+      (TFSServices.getItemContentWithHeaders as jest.Mock).mockImplementation(() =>
+        Promise.resolve({
+          data: { value: [] },
+          headers: { 'x-ms-continuationtoken': 'next-page' },
+        })
+      );
+
+      await expect(
+        pipelinesDataProvider.findPreviousSuccessfulRelease('project1', '456', 100)
+      ).rejects.toThrow('Release discovery exceeded 50 pages');
+    });
+  });
+
+  describe('findLatestSuccessfulRelease', () => {
+    const releaseCandidate = (id: number, status = 'succeeded') => ({
+      id,
+      status: 'active',
+      environments: [{ status }],
+      releaseDefinition: { id: 456 },
+    });
+
+    it('should find latest successful release on a later Release API page', async () => {
+      (TFSServices.getItemContentWithHeaders as jest.Mock)
+        .mockResolvedValueOnce({
+          data: { value: [releaseCandidate(100, 'failed')] },
+          headers: { 'x-ms-continuationtoken': 'next-page' },
+        })
+        .mockResolvedValueOnce({
+          data: { value: [releaseCandidate(90)] },
+          headers: {},
+        });
+
+      const result = await pipelinesDataProvider.findLatestSuccessfulRelease('project1', '456');
+
+      expect(result).toBe(90);
+      expect(TFSServices.getItemContentWithHeaders).toHaveBeenCalledWith(
+        expect.stringContaining('continuationToken=next-page'),
+        mockToken,
+        'get',
+        null,
+        null
+      );
+    });
+
+    it('should retry latest release discovery with api-version 6.0 only for unsupported api-version errors', async () => {
+      const unsupportedError: any = new Error('The requested resource does not support api-version 7.1');
+      unsupportedError.response = { status: 404 };
+
+      (TFSServices.getItemContentWithHeaders as jest.Mock)
+        .mockRejectedValueOnce(unsupportedError)
+        .mockResolvedValueOnce({
+          data: { value: [releaseCandidate(101)] },
+          headers: {},
+        });
+
+      const result = await pipelinesDataProvider.findLatestSuccessfulRelease('project1', '456');
+
+      expect(result).toBe(101);
+      expect((TFSServices.getItemContentWithHeaders as jest.Mock).mock.calls[0][0]).toContain(
+        'api-version=7.1'
+      );
+      expect((TFSServices.getItemContentWithHeaders as jest.Mock).mock.calls[1][0]).toContain(
+        'api-version=6.0'
+      );
+    });
+
+    it('should retry latest release discovery when unsupported api-version is reported in Axios response data', async () => {
+      const unsupportedError: any = new Error('Request failed with status code 404');
+      unsupportedError.response = {
+        status: 404,
+        data: { message: 'The requested resource does not support api-version 7.1' },
+      };
+
+      (TFSServices.getItemContentWithHeaders as jest.Mock)
+        .mockRejectedValueOnce(unsupportedError)
+        .mockResolvedValueOnce({
+          data: { value: [releaseCandidate(102)] },
+          headers: {},
+        });
+
+      const result = await pipelinesDataProvider.findLatestSuccessfulRelease('project1', '456');
+
+      expect(result).toBe(102);
+      expect((TFSServices.getItemContentWithHeaders as jest.Mock).mock.calls[1][0]).toContain(
+        'api-version=6.0'
+      );
+    });
+
+    it('should not retry latest release discovery for ordinary 404 errors', async () => {
+      const invalidDefinitionError: any = new Error('Release definition 456 was not found');
+      invalidDefinitionError.response = { status: 404 };
+      (TFSServices.getItemContentWithHeaders as jest.Mock).mockRejectedValueOnce(invalidDefinitionError);
+
+      await expect(
+        pipelinesDataProvider.findLatestSuccessfulRelease('project1', '456')
+      ).rejects.toThrow('Release definition 456 was not found');
+
+      expect(TFSServices.getItemContentWithHeaders).toHaveBeenCalledTimes(1);
+    });
+
+    it('should throw when latest release discovery exceeds the defensive page limit', async () => {
+      (TFSServices.getItemContentWithHeaders as jest.Mock).mockImplementation(() =>
+        Promise.resolve({
+          data: { value: [] },
+          headers: { 'x-ms-continuationtoken': 'next-page' },
+        })
+      );
+
+      await expect(
+        pipelinesDataProvider.findLatestSuccessfulRelease('project1', '456')
+      ).rejects.toThrow('Release discovery exceeded 50 pages');
     });
   });
 
@@ -877,12 +1168,40 @@ describe('PipelinesDataProvider', () => {
   });
 
   describe('findPreviousPipeline', () => {
+    const targetPipelineRun = {
+      resources: {
+        repositories: {
+          '0': {
+            self: {
+              repository: { id: 'repo1' },
+              version: 'target-sha',
+              refName: 'refs/heads/main',
+            },
+          },
+        },
+      },
+    } as unknown as PipelineRun;
+
+    const buildCandidate = (id: number, branchName: string, repoId = 'repo1') => ({
+      id,
+      status: 'completed',
+      result: 'succeeded',
+      sourceBranch: branchName,
+      sourceVersion: `sha-${id}`,
+      repository: { id: repoId },
+      definition: { id: 123 },
+    });
+
     it('should return undefined when no pipeline runs exist', async () => {
       // Arrange
       const teamProject = 'project1';
       const pipelineId = '123';
       const toPipelineRunId = 100;
       const targetPipeline = {} as PipelineRun;
+      (TFSServices.getItemContentWithHeaders as jest.Mock).mockResolvedValueOnce({
+        data: { value: [] },
+        headers: {},
+      });
       (TFSServices.getItemContent as jest.Mock).mockResolvedValueOnce({});
 
       // Act
@@ -908,6 +1227,15 @@ describe('PipelinesDataProvider', () => {
         },
       } as any;
 
+      (TFSServices.getItemContentWithHeaders as jest.Mock)
+        .mockResolvedValueOnce({
+          data: { value: [] },
+          headers: {},
+        })
+        .mockResolvedValueOnce({
+          data: { value: [] },
+          headers: {},
+        });
       (TFSServices.getItemContent as jest.Mock).mockResolvedValueOnce({
         value: [
           { id: 100, result: 'succeeded' },
@@ -938,6 +1266,10 @@ describe('PipelinesDataProvider', () => {
       const toPipelineRunId = 100;
       const targetPipeline = {} as PipelineRun;
 
+      (TFSServices.getItemContentWithHeaders as jest.Mock).mockResolvedValueOnce({
+        data: { value: [] },
+        headers: {},
+      });
       (TFSServices.getItemContent as jest.Mock).mockResolvedValueOnce({
         value: [{ id: 99, result: 'succeeded' }],
       });
@@ -955,6 +1287,7 @@ describe('PipelinesDataProvider', () => {
 
       expect(res).toBeUndefined();
       expect(detailsSpy).not.toHaveBeenCalled();
+      expect(TFSServices.getItemContentWithHeaders).not.toHaveBeenCalled();
     });
 
     it('should skip when pipeline details do not include repositories', async () => {
@@ -1018,6 +1351,15 @@ describe('PipelinesDataProvider', () => {
         },
       };
 
+      (TFSServices.getItemContentWithHeaders as jest.Mock)
+        .mockResolvedValueOnce({
+          data: { value: [] },
+          headers: {},
+        })
+        .mockResolvedValueOnce({
+          data: { value: [] },
+          headers: {},
+        });
       (TFSServices.getItemContent as jest.Mock)
         .mockResolvedValueOnce(mockRunHistory)
         .mockResolvedValueOnce(mockPipelineDetails);
@@ -1033,6 +1375,171 @@ describe('PipelinesDataProvider', () => {
 
       // Assert
       expect(result).toBe(99);
+    });
+
+    it('should find previous successful build on a later Builds API page', async () => {
+      (TFSServices.getItemContentWithHeaders as jest.Mock)
+        .mockResolvedValueOnce({
+          data: { value: [] },
+          headers: { 'x-ms-continuationtoken': 'next-page' },
+        })
+        .mockResolvedValueOnce({
+          data: { value: [buildCandidate(80, 'refs/heads/main')] },
+          headers: {},
+        });
+
+      const result = await pipelinesDataProvider.findPreviousPipeline(
+        'project1',
+        '123',
+        100,
+        targetPipelineRun,
+        true
+      );
+
+      expect(result).toBe(80);
+      expect(TFSServices.getItemContentWithHeaders).toHaveBeenCalledWith(
+        expect.stringContaining('continuationToken=next-page'),
+        mockToken,
+        'get',
+        null,
+        null
+      );
+    });
+
+    it('should prefer a same-branch successful build before trying cross-branch fallback', async () => {
+      (TFSServices.getItemContentWithHeaders as jest.Mock).mockResolvedValueOnce({
+        data: { value: [buildCandidate(90, 'refs/heads/main')] },
+        headers: {},
+      });
+
+      const result = await pipelinesDataProvider.findPreviousPipeline(
+        'project1',
+        '123',
+        100,
+        targetPipelineRun,
+        true
+      );
+
+      expect(result).toBe(90);
+      expect(TFSServices.getItemContentWithHeaders).toHaveBeenCalledTimes(1);
+      expect((TFSServices.getItemContentWithHeaders as jest.Mock).mock.calls[0][0]).toContain(
+        'branchName=refs%2Fheads%2Fmain'
+      );
+    });
+
+    it('should fall back to a different branch only when same-branch discovery fails', async () => {
+      (TFSServices.getItemContentWithHeaders as jest.Mock)
+        .mockResolvedValueOnce({
+          data: { value: [] },
+          headers: {},
+        })
+        .mockResolvedValueOnce({
+          data: { value: [buildCandidate(95, 'refs/heads/release')] },
+          headers: {},
+        });
+
+      const result = await pipelinesDataProvider.findPreviousPipeline(
+        'project1',
+        '123',
+        100,
+        targetPipelineRun,
+        true
+      );
+
+      expect(result).toBe(95);
+      expect(TFSServices.getItemContentWithHeaders).toHaveBeenCalledTimes(2);
+      expect((TFSServices.getItemContentWithHeaders as jest.Mock).mock.calls[0][0]).toContain(
+        'branchName=refs%2Fheads%2Fmain'
+      );
+      expect((TFSServices.getItemContentWithHeaders as jest.Mock).mock.calls[1][0]).not.toContain(
+        'branchName='
+      );
+    });
+
+    it('should query completed successful builds and ignore non-previous candidates', async () => {
+      (TFSServices.getItemContentWithHeaders as jest.Mock)
+        .mockResolvedValueOnce({
+          data: { value: [buildCandidate(100, 'refs/heads/main'), buildCandidate(101, 'refs/heads/main')] },
+          headers: {},
+        })
+        .mockResolvedValueOnce({
+          data: { value: [] },
+          headers: {},
+        });
+      (TFSServices.getItemContent as jest.Mock).mockResolvedValueOnce({});
+
+      const result = await pipelinesDataProvider.findPreviousPipeline(
+        'project1',
+        '123',
+        100,
+        targetPipelineRun,
+        true
+      );
+
+      const url = (TFSServices.getItemContentWithHeaders as jest.Mock).mock.calls[0][0];
+      expect(url).toContain('definitions=123');
+      expect(url).toContain('resultFilter=succeeded');
+      expect(url).toContain('statusFilter=completed');
+      expect(url).toContain('queryOrder=finishTimeDescending');
+      expect(result).toBeUndefined();
+    });
+
+    it('should throw and not try cross-branch fallback when same-branch Builds API fails', async () => {
+      (TFSServices.getItemContentWithHeaders as jest.Mock).mockRejectedValueOnce(new Error('same branch failed'));
+
+      await expect(
+        pipelinesDataProvider.findPreviousPipeline('project1', '123', 100, targetPipelineRun, true)
+      ).rejects.toThrow('same branch failed');
+
+      expect(TFSServices.getItemContentWithHeaders).toHaveBeenCalledTimes(1);
+      expect((TFSServices.getItemContentWithHeaders as jest.Mock).mock.calls[0][0]).toContain(
+        'branchName=refs%2Fheads%2Fmain'
+      );
+      expect(TFSServices.getItemContent).not.toHaveBeenCalled();
+    });
+
+    it('should throw when cross-branch Builds API fallback fails after same-branch no-match', async () => {
+      (TFSServices.getItemContentWithHeaders as jest.Mock)
+        .mockResolvedValueOnce({
+          data: { value: [] },
+          headers: {},
+        })
+        .mockRejectedValueOnce(new Error('fallback failed'));
+
+      await expect(
+        pipelinesDataProvider.findPreviousPipeline('project1', '123', 100, targetPipelineRun, true)
+      ).rejects.toThrow('fallback failed');
+
+      expect(TFSServices.getItemContentWithHeaders).toHaveBeenCalledTimes(2);
+      expect((TFSServices.getItemContentWithHeaders as jest.Mock).mock.calls[1][0]).not.toContain(
+        'branchName='
+      );
+    });
+
+    it('should throw when a later Builds API page fails', async () => {
+      (TFSServices.getItemContentWithHeaders as jest.Mock)
+        .mockResolvedValueOnce({
+          data: { value: [] },
+          headers: { 'x-ms-continuationtoken': 'next-page' },
+        })
+        .mockRejectedValueOnce(new Error('build page failed'));
+
+      await expect(
+        pipelinesDataProvider.findPreviousPipeline('project1', '123', 100, targetPipelineRun, true)
+      ).rejects.toThrow('build page failed');
+    });
+
+    it('should throw when previous build discovery exceeds the defensive page limit', async () => {
+      (TFSServices.getItemContentWithHeaders as jest.Mock).mockImplementation(() =>
+        Promise.resolve({
+          data: { value: [] },
+          headers: { 'x-ms-continuationtoken': 'next-page' },
+        })
+      );
+
+      await expect(
+        pipelinesDataProvider.findPreviousPipeline('project1', '123', 100, targetPipelineRun, true)
+      ).rejects.toThrow('Pipeline discovery exceeded 50 pages');
     });
   });
 

--- a/src/tests/modules/ticketsDataProvider.test.ts
+++ b/src/tests/modules/ticketsDataProvider.test.ts
@@ -1029,6 +1029,11 @@ describe('TicketsDataProvider', () => {
           icon: expect.objectContaining({ dataUrl: 'data:image/png;base64,xxx' }),
         }),
       );
+      expect(TFSServices.getItemContent).toHaveBeenCalledWith(
+        expect.stringContaining('/_apis/wit/workitemtypes?api-version=5.1'),
+        expect.any(String),
+      );
+      expect((TFSServices.getItemContent as jest.Mock).mock.calls[0][0]).not.toContain('api-version=5.1:');
       expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('Failed to download icon'));
     });
   });


### PR DESCRIPTION
- use Builds API as primary source for previous successful pipeline discovery
- page build discovery and prefer same-branch matches before cross-branch fallback
- fail discovery on ADO/API errors instead of silently falling back
- add previous/latest successful release discovery with paged release history
- retry release discovery with api-version 6.0 only for unsupported 7.1 responses
- fail release history pagination on partial reads
- add defensive discovery page cap
- fix ADO work item type URL construction and retry handling
- add regression coverage for buried history, branch fallback, release discovery, and failure paths