### PR TITLE
feat(svd): expose GetBuildWorkItems and GetLinkedRelatedItemsForSVD f…

### DIFF
--- a/src/modules/GitDataProvider.ts
+++ b/src/modules/GitDataProvider.ts
@@ -634,6 +634,10 @@ export default class GitDataProvider {
     return linkedItems;
   }
 
+  async GetLinkedRelatedItemsForSVD(linkedWiOptions: any, populatedWorkItem: any) {
+    return this.createLinkedRelatedItemsForSVD(linkedWiOptions, populatedWorkItem);
+  }
+
   async GetCommitsInDateRange(
     projectId: string,
     repositoryId: string,

--- a/src/modules/PipelinesDataProvider.ts
+++ b/src/modules/PipelinesDataProvider.ts
@@ -22,6 +22,20 @@ export default class PipelinesDataProvider {
   }
 
   /**
+   * Returns work item references associated with one completed build.
+   *
+   * Used by template-only first-run SVD baseline generation, where there is no
+   * previous successful build to compare against and the current target build's
+   * linked work items become the baseline content.
+   */
+  public async GetBuildWorkItems(teamProject: string, buildId: number): Promise<any[]> {
+    const encodedProject = encodeURIComponent(teamProject);
+    const url = `${this.orgUrl}${encodedProject}/_apis/build/builds/${buildId}/workitems?$top=2000&api-version=6.0`;
+    const result = await TFSServices.getItemContent(url, this.token, 'get');
+    return Array.isArray(result?.value) ? result.value : [];
+  }
+
+  /**
    * Resolves the previous pipeline run used as the source side of an SVD pipeline range.
    *
    * For regular pipeline ranges, the Builds API is used first because it supports paging,

--- a/src/tests/modules/gitDataProvider.test.ts
+++ b/src/tests/modules/gitDataProvider.test.ts
@@ -2569,6 +2569,37 @@ describe('GitDataProvider - createLinkedRelatedItemsForSVD', () => {
     );
   });
 
+  it('GetLinkedRelatedItemsForSVD should expose the shared linked WI enrichment for callers', async () => {
+    jest.spyOn((gitDataProvider as any).ticketsDataProvider, 'GetWorkItemByUrl').mockResolvedValueOnce({
+      id: 10,
+      fields: { 'System.WorkItemType': 'Requirement', 'System.Title': 'Req' },
+      _links: { html: { href: 'http://example.com/10' } },
+    });
+
+    const res = await gitDataProvider.GetLinkedRelatedItemsForSVD(
+      { isEnabled: true, linkedWiTypes: 'reqOnly', linkedWiRelationship: 'affectsOnly' },
+      {
+        id: 1,
+        relations: [
+          {
+            url: 'https://example.com/_apis/wit/workItems/10',
+            rel: 'Affects',
+            attributes: { name: 'Affects' },
+          },
+        ],
+      }
+    );
+
+    expect(res).toHaveLength(1);
+    expect(res[0]).toEqual(
+      expect.objectContaining({
+        id: 10,
+        wiType: 'Requirement',
+        relationType: 'Affects',
+      })
+    );
+  });
+
   it('should add Feature when linkedWiTypes=featureOnly and linkedWiRelationship=coversOnly', async () => {
     jest.spyOn((gitDataProvider as any).ticketsDataProvider, 'GetWorkItemByUrl').mockResolvedValueOnce({
       id: 11,

--- a/src/tests/modules/pipelineDataProvider.test.ts
+++ b/src/tests/modules/pipelineDataProvider.test.ts
@@ -18,6 +18,36 @@ describe('PipelinesDataProvider', () => {
     pipelinesDataProvider = new PipelinesDataProvider(mockOrgUrl, mockToken);
   });
 
+  describe('GetBuildWorkItems', () => {
+    it('should return work item references associated with a single build', async () => {
+      (TFSServices.getItemContent as jest.Mock).mockResolvedValue({
+        value: [{ id: '1', url: 'https://example.test/wi/1' }],
+      });
+
+      const result = await pipelinesDataProvider.GetBuildWorkItems('project1', 123);
+
+      expect(TFSServices.getItemContent).toHaveBeenCalledWith(
+        'https://dev.azure.com/orgname/project1/_apis/build/builds/123/workitems?$top=2000&api-version=6.0',
+        mockToken,
+        'get'
+      );
+      expect(result).toEqual([{ id: '1', url: 'https://example.test/wi/1' }]);
+    });
+
+    it('should encode project names in the build work items URL', async () => {
+      (TFSServices.getItemContent as jest.Mock).mockResolvedValue({});
+
+      const result = await pipelinesDataProvider.GetBuildWorkItems('Project With Spaces', 123);
+
+      expect(TFSServices.getItemContent).toHaveBeenCalledWith(
+        'https://dev.azure.com/orgname/Project%20With%20Spaces/_apis/build/builds/123/workitems?$top=2000&api-version=6.0',
+        mockToken,
+        'get'
+      );
+      expect(result).toEqual([]);
+    });
+  });
+
   describe('isMatchingPipeline', () => {
     // Create test method to access private method
     const invokeIsMatchingPipeline = (


### PR DESCRIPTION
…or baseline SVD

- Add GetBuildWorkItems to PipelinesDataProvider to fetch work items associated with a specific build via the ADO builds API. Expose the existing private createLinkedRelatedItemsForSVD as a public method on GitDataProvider.

- Both methods are consumed by content-control to hydrate a first-run SVD baseline when no previous successful build or release exists to diff against.