### PR TITLE
refactor(pipelines): remove same-commit filter, fix on-prem repo URL

### DIFF
--- a/src/models/tfs-data.ts
+++ b/src/models/tfs-data.ts
@@ -238,6 +238,7 @@ export interface Repository {
   id: string;
   name: string;
   url: string;
+  project?: { id: string; name: string };
 }
 
 export interface ResourceRepository {

--- a/src/modules/GitDataProvider.ts
+++ b/src/modules/GitDataProvider.ts
@@ -507,10 +507,6 @@ export default class GitDataProvider {
       //Then extend the commit information with the related WIs
       for (const extendedCommit of extendedCommits) {
         const { commit } = extendedCommit;
-        logger.info(
-          `getItemsForPipelineRange: commit ${commit?.commitId?.substring(0, 7)} ` +
-          `workItems=${JSON.stringify(commit?.workItems ?? null)}`
-        );
         if (!Array.isArray(commit.workItems) || commit.workItems.length === 0) {
           if (includeUnlinkedCommits) {
             commitsWithNoRelations.push({
@@ -924,10 +920,6 @@ export default class GitDataProvider {
 
       let url = `${gitUrl}/commitsbatch?$skip=${skipping}&$top=${chunkSize}&api-version=5.1`;
       let commitsResponse = await TFSServices.postRequest(url, this.token, undefined, body);
-      logger.info(
-        `GetCommitBatch raw: url=${url}, count=${commitsResponse.data?.count ?? 0}, ` +
-        `first=${JSON.stringify(commitsResponse.data?.value?.[0])}`
-      );
       let commits = commitsResponse.data;
       while (commits.count > 0) {
         for (const commit of commits.value) {

--- a/src/modules/PipelinesDataProvider.ts
+++ b/src/modules/PipelinesDataProvider.ts
@@ -46,7 +46,6 @@ export default class PipelinesDataProvider {
    * @param pipelineId Pipeline/build definition id.
    * @param toPipelineRunId Target run/build id. Candidates must be older than this id.
    * @param targetPipeline Full target pipeline run details, used for repository/branch matching.
-   * @param searchPrevPipelineFromDifferentCommit When true, skip candidates from the same commit.
    * @param fromStage Optional stage name. When set, only previous runs with this successful stage match.
    */
   public async findPreviousPipeline(
@@ -54,7 +53,6 @@ export default class PipelinesDataProvider {
     pipelineId: string,
     toPipelineRunId: number,
     targetPipeline: any,
-    searchPrevPipelineFromDifferentCommit: boolean,
     fromStage: string = ''
   ) {
     if (!fromStage) {
@@ -62,8 +60,7 @@ export default class PipelinesDataProvider {
         teamProject,
         pipelineId,
         toPipelineRunId,
-        targetPipeline,
-        searchPrevPipelineFromDifferentCommit
+        targetPipeline
       );
       if (previousBuildId) {
         return previousBuildId;
@@ -89,7 +86,7 @@ export default class PipelinesDataProvider {
         continue;
       }
 
-      if (this.isMatchingPipeline(fromPipeline, targetPipeline, searchPrevPipelineFromDifferentCommit)) {
+      if (this.isMatchingPipeline(fromPipeline, targetPipeline)) {
         return pipelineRun.id;
       }
     }
@@ -109,8 +106,7 @@ export default class PipelinesDataProvider {
     teamProject: string,
     definitionId: string,
     toBuildId: number,
-    targetPipeline: any,
-    searchPrevPipelineFromDifferentCommit: boolean
+    targetPipeline: any
   ): Promise<number | undefined> {
     const targetRepo = this.getPrimaryPipelineRepository(targetPipeline);
     const targetBranch = this.normalizeBranchName(targetRepo?.refName);
@@ -121,7 +117,6 @@ export default class PipelinesDataProvider {
         definitionId,
         toBuildId,
         targetPipeline,
-        searchPrevPipelineFromDifferentCommit,
         targetBranch
       );
       if (sameBranchResult.status === 'failed') {
@@ -136,8 +131,7 @@ export default class PipelinesDataProvider {
       teamProject,
       definitionId,
       toBuildId,
-      targetPipeline,
-      searchPrevPipelineFromDifferentCommit
+      targetPipeline
     );
     if (anyBranchResult.status === 'failed') {
       throw anyBranchResult.error;
@@ -157,7 +151,6 @@ export default class PipelinesDataProvider {
     definitionId: string,
     toBuildId: number,
     targetPipeline: any,
-    searchPrevPipelineFromDifferentCommit: boolean,
     branchName?: string
   ): Promise<PreviousDiscoveryResult> {
     const targetRepo = this.getPrimaryPipelineRepository(targetPipeline);
@@ -189,7 +182,6 @@ export default class PipelinesDataProvider {
             build,
             targetRepo,
             toBuildId,
-            searchPrevPipelineFromDifferentCommit,
             branchName
           )
         );
@@ -234,14 +226,12 @@ export default class PipelinesDataProvider {
    * Validates a Builds API candidate against the target run.
    *
    * A candidate must be older than the target, completed successfully, from the same
-   * repository, and optionally from the required branch. When the caller asks for a
-   * different commit, candidates with the same source version are excluded.
+   * repository, and optionally from the required branch.
    */
   private isMatchingPreviousBuild(
     build: any,
     targetRepo: any,
     toBuildId: number,
-    searchPrevPipelineFromDifferentCommit: boolean,
     requiredBranch?: string
   ): boolean {
     const buildId = Number(build?.id);
@@ -254,10 +244,6 @@ export default class PipelinesDataProvider {
     if (!buildRepoId || !targetRepoId || buildRepoId !== targetRepoId) return false;
 
     if (requiredBranch && build?.sourceBranch !== requiredBranch) return false;
-
-    if (build?.sourceVersion && targetRepo?.version && build.sourceVersion === targetRepo.version) {
-      return !searchPrevPipelineFromDifferentCommit;
-    }
 
     return true;
   }
@@ -467,17 +453,15 @@ export default class PipelinesDataProvider {
   }
 
   /**
-   * Determines if two pipelines match based on their repository and version information.
+   * Determines if two pipelines match based on their repository and branch.
    *
    * @param fromPipeline - The source pipeline to compare.
    * @param targetPipeline - The target pipeline to compare against.
-   * @param searchPrevPipelineFromDifferentCommit - A flag indicating whether to search for a previous pipeline from a different commit.
-   * @returns `true` if the pipelines match based on the repository and version criteria; otherwise, `false`.
+   * @returns `true` if the pipelines share the same repository and ref; otherwise, `false`.
    */
   private isMatchingPipeline(
     fromPipeline: PipelineRun,
-    targetPipeline: PipelineRun,
-    searchPrevPipelineFromDifferentCommit: boolean
+    targetPipeline: PipelineRun
   ): boolean {
     if (!fromPipeline?.resources?.repositories || !targetPipeline?.resources?.repositories) {
       return false;
@@ -498,10 +482,6 @@ export default class PipelinesDataProvider {
 
     if (fromRepo.repository.id !== targetRepo.repository.id) {
       return false;
-    }
-
-    if (fromRepo.version === targetRepo.version) {
-      return !searchPrevPipelineFromDifferentCommit;
     }
 
     return fromRepo.refName === targetRepo.refName;
@@ -995,6 +975,18 @@ export default class PipelinesDataProvider {
    * @param gitDataProviderInstance - An instance of GitDataProvider to fetch repository details.
    * @returns A promise that resolves to an array of unique resource repositories.
    */
+  /**
+   * Rebuilds a repository API URL using the project name rather than the UUID that TFS
+   * returns in repo.url. On-prem TFS indexes WI-to-commit associations by project name, so
+   * commitsbatch requests must use the name form to receive populated workItems arrays.
+   */
+  private buildRepoApiUrl(repo: Repository): string {
+    const projectName = repo.project?.name;
+    return projectName
+      ? `${this.orgUrl}${projectName}/_apis/git/repositories/${repo.id}`
+      : repo.url;
+  }
+
   public async getPipelineResourceRepositoriesFromObject(
     inPipeline: PipelineRun,
     gitDataProviderInstance: GitDataProvider
@@ -1015,10 +1007,11 @@ export default class PipelinesDataProvider {
       if (!repoId) continue;
 
       const repo: Repository = await gitDataProviderInstance.GetGitRepoFromRepoId(repoId);
+      const repoApiUrl = this.buildRepoApiUrl(repo);
       const resourceRepository: ResourceRepository = {
         repoName: repo.name,
         repoSha1: resourceRepo.version,
-        url: repo.url,
+        url: repoApiUrl,
       };
       const key = String(repoId);
       if (!resourceRepositoriesById.has(key)) {

--- a/src/tests/modules/pipelineDataProvider.test.ts
+++ b/src/tests/modules/pipelineDataProvider.test.ts
@@ -52,14 +52,9 @@ describe('PipelinesDataProvider', () => {
     // Create test method to access private method
     const invokeIsMatchingPipeline = (
       fromPipeline: PipelineRun,
-      targetPipeline: PipelineRun,
-      searchPrevPipelineFromDifferentCommit: boolean
+      targetPipeline: PipelineRun
     ): boolean => {
-      return (pipelinesDataProvider as any).isMatchingPipeline(
-        fromPipeline,
-        targetPipeline,
-        searchPrevPipelineFromDifferentCommit
-      );
+      return (pipelinesDataProvider as any).isMatchingPipeline(fromPipeline, targetPipeline);
     };
 
     it('should return false when repository IDs are different', () => {
@@ -93,13 +88,13 @@ describe('PipelinesDataProvider', () => {
       } as unknown as PipelineRun;
 
       // Act
-      const result = invokeIsMatchingPipeline(fromPipeline, targetPipeline, false);
+      const result = invokeIsMatchingPipeline(fromPipeline, targetPipeline);
 
       // Assert
       expect(result).toBe(false);
     });
 
-    it('should return true when versions are the same and searchPrevPipelineFromDifferentCommit is false', () => {
+    it('should return true when versions are the same and refNames match', () => {
       // Arrange
       const fromPipeline = {
         resources: {
@@ -130,47 +125,10 @@ describe('PipelinesDataProvider', () => {
       } as unknown as PipelineRun;
 
       // Act
-      const result = invokeIsMatchingPipeline(fromPipeline, targetPipeline, false);
+      const result = invokeIsMatchingPipeline(fromPipeline, targetPipeline);
 
       // Assert
       expect(result).toBe(true);
-    });
-
-    it('should return false when versions are the same and searchPrevPipelineFromDifferentCommit is true', () => {
-      // Arrange
-      const fromPipeline = {
-        resources: {
-          repositories: {
-            '0': {
-              self: {
-                repository: { id: 'repo1' },
-                version: 'v1',
-                refName: 'refs/heads/main',
-              },
-            },
-          },
-        },
-      } as unknown as PipelineRun;
-
-      const targetPipeline = {
-        resources: {
-          repositories: {
-            '0': {
-              self: {
-                repository: { id: 'repo1' },
-                version: 'v1',
-                refName: 'refs/heads/main',
-              },
-            },
-          },
-        },
-      } as unknown as PipelineRun;
-
-      // Act
-      const result = invokeIsMatchingPipeline(fromPipeline, targetPipeline, true);
-
-      // Assert
-      expect(result).toBe(false);
     });
 
     it('should return true when refNames match but versions differ', () => {
@@ -204,7 +162,7 @@ describe('PipelinesDataProvider', () => {
       } as unknown as PipelineRun;
 
       // Act
-      const result = invokeIsMatchingPipeline(fromPipeline, targetPipeline, true);
+      const result = invokeIsMatchingPipeline(fromPipeline, targetPipeline);
 
       // Assert
       expect(result).toBe(true);
@@ -237,7 +195,7 @@ describe('PipelinesDataProvider', () => {
       } as unknown as PipelineRun;
 
       // Act
-      const result = invokeIsMatchingPipeline(fromPipeline, targetPipeline, false);
+      const result = invokeIsMatchingPipeline(fromPipeline, targetPipeline);
 
       // Assert
       expect(result).toBe(true);
@@ -270,7 +228,7 @@ describe('PipelinesDataProvider', () => {
         },
       } as unknown as PipelineRun;
 
-      const result = invokeIsMatchingPipeline(fromPipeline, targetPipeline, false);
+      const result = invokeIsMatchingPipeline(fromPipeline, targetPipeline);
       expect(result).toBe(true);
     });
   });
@@ -1176,8 +1134,10 @@ describe('PipelinesDataProvider', () => {
       } as unknown as PipelineRun;
 
       const mockRepo = {
+        id: 'repo-123',
         name: 'MyRepo',
         url: 'https://dev.azure.com/org/project/_git/MyRepo',
+        // no project field → falls back to repo.url
       };
 
       const mockGitDataProvider = {
@@ -1197,6 +1157,45 @@ describe('PipelinesDataProvider', () => {
         repoSha1: 'abc123',
         url: 'https://dev.azure.com/org/project/_git/MyRepo',
       });
+    });
+
+    it('should use project-name URL when repo response includes project.name (on-prem TFS WI fix)', async () => {
+      // On-prem TFS canonicalizes repo.url to a project-UUID form, but commitsbatch only
+      // resolves workItems when the URL uses the project name. This test verifies the URL
+      // is rewritten to project-name form when project.name is available.
+      const inPipeline = {
+        resources: {
+          repositories: {
+            self: {
+              repository: { id: 'b671b0fa-1111-2222-3333-444444444444', type: 'TfsGit' },
+              version: 'abc123',
+            },
+          },
+        },
+      } as unknown as PipelineRun;
+
+      const mockRepo = {
+        id: 'b671b0fa-1111-2222-3333-444444444444',
+        name: 'eden1',
+        url: 'http://elis-tfs:8080/tfs/ElisraCollection/5d662fe5-uuid/_apis/git/repositories/b671b0fa-1111-2222-3333-444444444444',
+        project: { id: '5d662fe5-uuid', name: 'TestProject-CMMI' },
+      };
+
+      const mockGitDataProvider = {
+        GetGitRepoFromRepoId: jest.fn().mockResolvedValue(mockRepo),
+      } as unknown as GitDataProvider;
+
+      // Act
+      const result = await pipelinesDataProvider.getPipelineResourceRepositoriesFromObject(
+        inPipeline,
+        mockGitDataProvider
+      );
+
+      // Assert — URL must use project NAME, not UUID
+      expect(result).toHaveLength(1);
+      expect((result as any[])[0].url).toContain('TestProject-CMMI');
+      expect((result as any[])[0].url).not.toContain('5d662fe5-uuid');
+      expect((result as any[])[0].url).toContain('b671b0fa-1111-2222-3333-444444444444');
     });
 
     it('should skip non-azureReposGit repositories', async () => {
@@ -1270,8 +1269,7 @@ describe('PipelinesDataProvider', () => {
         teamProject,
         pipelineId,
         toPipelineRunId,
-        targetPipeline,
-        false
+        targetPipeline
       );
 
       // Assert
@@ -1315,8 +1313,7 @@ describe('PipelinesDataProvider', () => {
         teamProject,
         pipelineId,
         toPipelineRunId,
-        targetPipeline,
-        true
+        targetPipeline
       );
       expect(res).toBe(99);
     });
@@ -1342,7 +1339,6 @@ describe('PipelinesDataProvider', () => {
         pipelineId,
         toPipelineRunId,
         targetPipeline,
-        false,
         'Deploy'
       );
 
@@ -1368,8 +1364,7 @@ describe('PipelinesDataProvider', () => {
         teamProject,
         pipelineId,
         toPipelineRunId,
-        targetPipeline,
-        false
+        targetPipeline
       );
 
       expect(res).toBeUndefined();
@@ -1430,8 +1425,7 @@ describe('PipelinesDataProvider', () => {
         teamProject,
         pipelineId,
         toPipelineRunId,
-        targetPipeline,
-        true
+        targetPipeline
       );
 
       // Assert
@@ -1453,8 +1447,7 @@ describe('PipelinesDataProvider', () => {
         'project1',
         '123',
         100,
-        targetPipelineRun,
-        true
+        targetPipelineRun
       );
 
       expect(result).toBe(80);
@@ -1477,8 +1470,7 @@ describe('PipelinesDataProvider', () => {
         'project1',
         '123',
         100,
-        targetPipelineRun,
-        true
+        targetPipelineRun
       );
 
       expect(result).toBe(90);
@@ -1503,8 +1495,7 @@ describe('PipelinesDataProvider', () => {
         'project1',
         '123',
         100,
-        targetPipelineRun,
-        true
+        targetPipelineRun
       );
 
       expect(result).toBe(95);
@@ -1533,8 +1524,7 @@ describe('PipelinesDataProvider', () => {
         'project1',
         '123',
         100,
-        targetPipelineRun,
-        true
+        targetPipelineRun
       );
 
       const url = (TFSServices.getItemContentWithHeaders as jest.Mock).mock.calls[0][0];
@@ -1549,7 +1539,7 @@ describe('PipelinesDataProvider', () => {
       (TFSServices.getItemContentWithHeaders as jest.Mock).mockRejectedValueOnce(new Error('same branch failed'));
 
       await expect(
-        pipelinesDataProvider.findPreviousPipeline('project1', '123', 100, targetPipelineRun, true)
+        pipelinesDataProvider.findPreviousPipeline('project1', '123', 100, targetPipelineRun)
       ).rejects.toThrow('same branch failed');
 
       expect(TFSServices.getItemContentWithHeaders).toHaveBeenCalledTimes(1);
@@ -1568,7 +1558,7 @@ describe('PipelinesDataProvider', () => {
         .mockRejectedValueOnce(new Error('fallback failed'));
 
       await expect(
-        pipelinesDataProvider.findPreviousPipeline('project1', '123', 100, targetPipelineRun, true)
+        pipelinesDataProvider.findPreviousPipeline('project1', '123', 100, targetPipelineRun)
       ).rejects.toThrow('fallback failed');
 
       expect(TFSServices.getItemContentWithHeaders).toHaveBeenCalledTimes(2);
@@ -1586,7 +1576,7 @@ describe('PipelinesDataProvider', () => {
         .mockRejectedValueOnce(new Error('build page failed'));
 
       await expect(
-        pipelinesDataProvider.findPreviousPipeline('project1', '123', 100, targetPipelineRun, true)
+        pipelinesDataProvider.findPreviousPipeline('project1', '123', 100, targetPipelineRun)
       ).rejects.toThrow('build page failed');
     });
 
@@ -1599,7 +1589,7 @@ describe('PipelinesDataProvider', () => {
       );
 
       await expect(
-        pipelinesDataProvider.findPreviousPipeline('project1', '123', 100, targetPipelineRun, true)
+        pipelinesDataProvider.findPreviousPipeline('project1', '123', 100, targetPipelineRun)
       ).rejects.toThrow('Pipeline discovery exceeded 50 pages');
     });
   });


### PR DESCRIPTION
- Remove `searchPrevPipelineFromDifferentCommit` flag from pipeline discovery — matching is now based solely on repository and branch.

- Add `buildRepoApiUrl` to rewrite TFS repo URLs from UUID-based to project-name-based form, fixing missing workItems on on-prem TFS.

- Add `project` field to `Repository` model to carry project name from the ADO Git API response.

- Remove debug log statements added during investigation.