### PR TITLE
fix(pipelines): remove cross-branch fallback, normalize repo project …

### DIFF
--- a/src/modules/PipelinesDataProvider.ts
+++ b/src/modules/PipelinesDataProvider.ts
@@ -96,9 +96,14 @@ export default class PipelinesDataProvider {
   /**
    * Finds the previous successful completed build for a definition.
    *
-   * Discovery prefers the target run's branch first. If no same-branch candidate exists, it
-   * falls back to the same repository on any branch so auto-discovery can still work for
-   * sparse branches or customer histories where the previous success is on another branch.
+   * Discovery order:
+   * 1. Same-branch search (preferred): pages the Builds API filtered to succeeded builds on the
+   *    same branch as the target run.
+   * 2. Ancestry-walk fallback: if no same-branch result, finds the merge-base between the
+   *    target commit and the default branch, then returns the latest default-branch build whose
+   *    sourceVersion is an ancestor of that merge-base. Useful for feature-branch first builds
+   *    that have never had a prior same-branch success.
+   * 3. Returns undefined if neither step finds a candidate (caller falls through to baseline).
    *
    * @returns Previous build id, or undefined when no valid candidate is found.
    */
@@ -125,6 +130,16 @@ export default class PipelinesDataProvider {
       if (sameBranchResult.status === 'found') {
         return sameBranchResult.id;
       }
+    }
+
+    const ancestryId = await this.findAncestryFallbackBuild(
+      teamProject,
+      definitionId,
+      toBuildId,
+      targetPipeline
+    );
+    if (ancestryId !== undefined) {
+      return ancestryId;
     }
 
     return undefined;
@@ -195,6 +210,187 @@ export default class PipelinesDataProvider {
     return { status: 'not_found' };
   }
 
+  /**
+   * Ancestry-walk fallback for findPreviousSuccessfulBuild.
+   *
+   * Used when no same-branch successful build exists. Resolves the merge-base between the
+   * target commit and the repo's default branch, then finds the latest default-branch build
+   * whose sourceVersion is an ancestor of that merge-base.
+   *
+   * Returns undefined (never throws) so the caller can fall through to baseline SVD mode.
+   */
+  private async findAncestryFallbackBuild(
+    teamProject: string,
+    definitionId: string,
+    toBuildId: number,
+    targetPipeline: any
+  ): Promise<number | undefined> {
+    try {
+      const targetRepo = this.getPrimaryPipelineRepository(targetPipeline);
+      const repoId = targetRepo?.repository?.id;
+      const targetSha = targetRepo?.version;
+
+      if (!repoId || !targetSha) {
+        return undefined;
+      }
+
+      const defaultBranch = await this.getRepoDefaultBranch(teamProject, repoId);
+      if (!defaultBranch) {
+        return undefined;
+      }
+      const normalizedDefault = this.normalizeBranchName(defaultBranch);
+      if (!normalizedDefault) {
+        return undefined;
+      }
+
+      const mergeBase = await this.getMergeBase(teamProject, repoId, defaultBranch, targetSha);
+      if (!mergeBase) {
+        return undefined;
+      }
+
+      logger.debug(
+        `[ancestry] target=${targetSha.substring(0, 7)} defaultBranch=${defaultBranch} mergeBase=${mergeBase.substring(0, 7)}`
+      );
+
+      let continuationToken: string | undefined;
+      let pageCount = 0;
+
+      do {
+        // encodeURIComponent(teamProject) is used here (and in getRepoDefaultBranch / getMergeBase)
+        // for consistency within the ancestry helpers. findPreviousSuccessfulBuildPage uses a bare
+        // teamProject segment — both forms are accepted by ADO, but they should be unified in a
+        // future cleanup pass.
+        let url =
+          `${this.orgUrl}${encodeURIComponent(teamProject)}/_apis/build/builds` +
+          `?definitions=${encodeURIComponent(String(definitionId))}` +
+          `&resultFilter=succeeded&statusFilter=completed` +
+          `&queryOrder=finishTimeDescending&$top=200&api-version=6.0` +
+          `&branchName=${encodeURIComponent(normalizedDefault)}`;
+        if (continuationToken) {
+          url += `&continuationToken=${encodeURIComponent(continuationToken)}`;
+        }
+
+        const { data, headers } = await TFSServices.getItemContentWithHeaders(
+          url,
+          this.token,
+          'get',
+          null,
+          null
+        );
+        pageCount++;
+        const builds: any[] = data?.value || [];
+
+        for (const build of builds) {
+          if (!this.isMatchingPreviousBuild(build, targetRepo, toBuildId, normalizedDefault)) {
+            continue;
+          }
+          const candidateSha: string | undefined = build.sourceVersion;
+          if (!candidateSha) continue;
+
+          const isAncestor = await this.isCommitAncestorOf(
+            teamProject,
+            repoId,
+            candidateSha,
+            mergeBase
+          );
+          if (isAncestor) {
+            logger.debug(
+              `[ancestry] selected build ${build.id} sourceVersion=${candidateSha.substring(0, 7)}`
+            );
+            return Number(build.id);
+          }
+        }
+
+        continuationToken = this.getContinuationToken(headers);
+        if (continuationToken && pageCount >= MAX_DISCOVERY_PAGES) {
+          logger.warn(`[ancestry] fallback exceeded ${MAX_DISCOVERY_PAGES} pages without match`);
+          return undefined;
+        }
+      } while (continuationToken);
+
+      return undefined;
+    } catch (err: unknown) {
+      logger.warn(`[ancestry] fallback failed: ${this.getErrorMessage(err)}`);
+      return undefined;
+    }
+  }
+
+  /**
+   * Returns the default branch name (e.g. "refs/heads/main") for a Git repository.
+   * Returns undefined if the repository cannot be fetched.
+   */
+  private async getRepoDefaultBranch(
+    teamProject: string,
+    repoId: string
+  ): Promise<string | undefined> {
+    const url = `${this.orgUrl}${encodeURIComponent(teamProject)}/_apis/git/repositories/${repoId}?api-version=6.0`;
+    try {
+      const result = await TFSServices.getItemContent(url, this.token, 'get', null, null, false);
+      return typeof result?.defaultBranch === 'string' && result.defaultBranch
+        ? result.defaultBranch
+        : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  /**
+   * Returns the merge-base commit SHA between a branch tip and a target commit SHA.
+   *
+   * Uses the ADO Git diffs/commits API:
+   *   baseVersion=<branchShortName> (branch type), targetVersion=<commitSha> (commit type)
+   * The returned commonCommit is the merge-base.
+   */
+  private async getMergeBase(
+    teamProject: string,
+    repoId: string,
+    defaultBranch: string,
+    targetSha: string
+  ): Promise<string | undefined> {
+    const branchShort = defaultBranch.replace(/^refs\/heads\//, '');
+    const url =
+      `${this.orgUrl}${encodeURIComponent(teamProject)}/_apis/git/repositories/${repoId}/diffs/commits` +
+      `?baseVersion=${encodeURIComponent(branchShort)}&baseVersionType=branch` +
+      `&targetVersion=${encodeURIComponent(targetSha)}&targetVersionType=commit` +
+      `&$top=1&api-version=6.0`;
+    try {
+      const result = await TFSServices.getItemContent(url, this.token, 'get', null, null, false);
+      return typeof result?.commonCommit === 'string' && result.commonCommit
+        ? result.commonCommit
+        : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  /**
+   * Returns true when candidateSha is an ancestor of (or equal to) targetSha.
+   *
+   * Uses the ADO Git diffs/commits API:
+   *   baseVersion=candidateSha (commit), targetVersion=targetSha (commit)
+   * If candidateSha is an ancestor of targetSha, it IS the common ancestor of the two,
+   * so commonCommit === candidateSha.
+   */
+  private async isCommitAncestorOf(
+    teamProject: string,
+    repoId: string,
+    candidateSha: string,
+    targetSha: string
+  ): Promise<boolean> {
+    if (candidateSha === targetSha) return true;
+    const url =
+      `${this.orgUrl}${encodeURIComponent(teamProject)}/_apis/git/repositories/${repoId}/diffs/commits` +
+      `?baseVersion=${encodeURIComponent(candidateSha)}&baseVersionType=commit` +
+      `&targetVersion=${encodeURIComponent(targetSha)}&targetVersionType=commit` +
+      `&$top=1&api-version=6.0`;
+    try {
+      const result = await TFSServices.getItemContent(url, this.token, 'get', null, null, false);
+      return result?.commonCommit === candidateSha;
+    } catch {
+      return false;
+    }
+  }
+
   private getContinuationToken(headers: any): string | undefined {
     return headers?.['x-ms-continuationtoken'] || headers?.['x-ms-continuation-token'] || undefined;
   }
@@ -210,7 +406,13 @@ export default class PipelinesDataProvider {
   private getPrimaryPipelineRepository(pipeline: any): any {
     const repositories = pipeline?.resources?.repositories;
     if (!repositories) return undefined;
-    return repositories.self || repositories[0]?.self || repositories.__designer_repo;
+    if (repositories.self) return repositories.self;
+    if (repositories.__designer_repo) return repositories.__designer_repo;
+    // resources.repositories is a plain named-key object (not an array), so [0] is always
+    // undefined. Fall back to the first value for pipelines using a custom checkout alias.
+    // Some older ADO pipeline formats wrap the repo under a nested .self key; unwrap if present.
+    const first = Object.values(repositories)[0] as any;
+    return first?.self ?? first ?? undefined;
   }
 
   /**
@@ -1039,7 +1241,7 @@ export default class PipelinesDataProvider {
    * @returns A promise that resolves to the content of the pipeline run.
    */
   async getPipelineRunDetails(projectName: string, pipelineId: number, runId: number): Promise<PipelineRun> {
-    let url = `${this.orgUrl}${projectName}/_apis/pipelines/${pipelineId}/runs/${runId}`;
+    let url = `${this.orgUrl}${projectName}/_apis/pipelines/${pipelineId}/runs/${runId}?$expand=resources`;
     return TFSServices.getItemContent(url, this.token);
   }
 

--- a/src/tests/modules/pipelineDataProvider.test.ts
+++ b/src/tests/modules/pipelineDataProvider.test.ts
@@ -247,7 +247,7 @@ describe('PipelinesDataProvider', () => {
 
       // Assert
       expect(TFSServices.getItemContent).toHaveBeenCalledWith(
-        `${mockOrgUrl}${projectName}/_apis/pipelines/${pipelineId}/runs/${runId}`,
+        `${mockOrgUrl}${projectName}/_apis/pipelines/${pipelineId}/runs/${runId}?$expand=resources`,
         mockToken
       );
       expect(result).toEqual(mockResponse);
@@ -1319,12 +1319,14 @@ describe('PipelinesDataProvider', () => {
         data: { value: [] },
         headers: {},
       });
-      (TFSServices.getItemContent as jest.Mock).mockResolvedValueOnce({
-        value: [
-          { id: 100, result: 'succeeded' },
-          { id: 99, result: 'succeeded' },
-        ],
-      });
+      (TFSServices.getItemContent as jest.Mock)
+        .mockResolvedValueOnce({}) // getRepoDefaultBranch (no defaultBranch → ancestry short-circuits)
+        .mockResolvedValueOnce({
+          value: [
+            { id: 100, result: 'succeeded' },
+            { id: 99, result: 'succeeded' },
+          ],
+        });
 
       jest.spyOn(pipelinesDataProvider as any, 'getPipelineRunDetails').mockResolvedValueOnce({
         resources: {
@@ -1432,6 +1434,7 @@ describe('PipelinesDataProvider', () => {
         headers: {},
       });
       (TFSServices.getItemContent as jest.Mock)
+        .mockResolvedValueOnce({}) // getRepoDefaultBranch (no defaultBranch → ancestry short-circuits)
         .mockResolvedValueOnce(mockRunHistory)
         .mockResolvedValueOnce(mockPipelineDetails);
 
@@ -1500,7 +1503,9 @@ describe('PipelinesDataProvider', () => {
         data: { value: [] },
         headers: {},
       });
-      (TFSServices.getItemContent as jest.Mock).mockResolvedValueOnce({ value: [] });
+      (TFSServices.getItemContent as jest.Mock)
+        .mockResolvedValueOnce({})           // getRepoDefaultBranch — no defaultBranch, ancestry exits
+        .mockResolvedValueOnce({ value: [] }); // GetPipelineRunHistory (legacy path)
 
       const result = await pipelinesDataProvider.findPreviousPipeline(
         'project1',
@@ -1521,7 +1526,9 @@ describe('PipelinesDataProvider', () => {
         data: { value: [buildCandidate(100, 'refs/heads/main'), buildCandidate(101, 'refs/heads/main')] },
         headers: {},
       });
-      (TFSServices.getItemContent as jest.Mock).mockResolvedValueOnce({});
+      (TFSServices.getItemContent as jest.Mock)
+        .mockResolvedValueOnce({})           // getRepoDefaultBranch — no defaultBranch, ancestry exits
+        .mockResolvedValueOnce({ value: [] }); // GetPipelineRunHistory (legacy path)
 
       const result = await pipelinesDataProvider.findPreviousPipeline(
         'project1',
@@ -1557,7 +1564,9 @@ describe('PipelinesDataProvider', () => {
         data: { value: [] },
         headers: {},
       });
-      (TFSServices.getItemContent as jest.Mock).mockResolvedValueOnce({ value: [] });
+      (TFSServices.getItemContent as jest.Mock)
+        .mockResolvedValueOnce({})           // getRepoDefaultBranch — no defaultBranch, ancestry exits
+        .mockResolvedValueOnce({ value: [] }); // GetPipelineRunHistory (legacy path)
 
       const result = await pipelinesDataProvider.findPreviousPipeline(
         'project1',
@@ -1594,6 +1603,139 @@ describe('PipelinesDataProvider', () => {
       await expect(
         pipelinesDataProvider.findPreviousPipeline('project1', '123', 100, targetPipelineRun)
       ).rejects.toThrow('Pipeline discovery exceeded 50 pages');
+    });
+
+    describe('ancestry-walk fallback', () => {
+      const featureTargetPipelineRun = {
+        resources: {
+          repositories: {
+            self: {
+              repository: { id: 'repo1' },
+              version: 'C3-B',
+              refName: 'refs/heads/feature/x',
+            },
+          },
+        },
+      } as unknown as PipelineRun;
+
+      beforeEach(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should return ancestry-resolved build when same-branch has no match', async () => {
+        // same-branch search: no candidates (empty)
+        (TFSServices.getItemContentWithHeaders as jest.Mock)
+          .mockResolvedValueOnce({ data: { value: [] }, headers: {} }) // same-branch
+          .mockResolvedValueOnce({                                       // ancestry default-branch page
+            data: {
+              value: [
+                buildCandidate(90, 'refs/heads/main'),  // id=90, sourceVersion='sha-90'
+                buildCandidate(70, 'refs/heads/main'),  // id=70, sourceVersion='sha-70'
+              ],
+            },
+            headers: {},
+          });
+
+        // getRepoDefaultBranch
+        (TFSServices.getItemContent as jest.Mock)
+          .mockResolvedValueOnce({ defaultBranch: 'refs/heads/main' })  // getRepoDefaultBranch
+          .mockResolvedValueOnce({ commonCommit: 'C3' })                // getMergeBase
+          .mockResolvedValueOnce({ commonCommit: 'unrelated-sha' })     // isCommitAncestorOf sha-90 vs C3 => false
+          .mockResolvedValueOnce({ commonCommit: 'sha-70' });           // isCommitAncestorOf sha-70 vs C3 => sha-70 == sha-70 -> true
+
+        const result = await pipelinesDataProvider.findPreviousPipeline(
+          'project1',
+          '123',
+          100,
+          featureTargetPipelineRun
+        );
+
+        expect(result).toBe(70);
+      });
+
+      it('should return undefined when ancestry walk finds no ancestor match', async () => {
+        (TFSServices.getItemContentWithHeaders as jest.Mock)
+          .mockResolvedValueOnce({ data: { value: [] }, headers: {} })  // same-branch
+          .mockResolvedValueOnce({                                        // ancestry default-branch page
+            data: { value: [buildCandidate(90, 'refs/heads/main')] },
+            headers: {},
+          });
+
+        (TFSServices.getItemContent as jest.Mock)
+          .mockResolvedValueOnce({ defaultBranch: 'refs/heads/main' })  // getRepoDefaultBranch
+          .mockResolvedValueOnce({ commonCommit: 'C3' })                // getMergeBase
+          .mockResolvedValueOnce({ commonCommit: 'unrelated-sha' })     // isCommitAncestorOf => false
+          .mockResolvedValueOnce({ value: [] });                         // GetPipelineRunHistory (legacy path)
+
+        const result = await pipelinesDataProvider.findPreviousPipeline(
+          'project1',
+          '123',
+          100,
+          featureTargetPipelineRun
+        );
+
+        expect(result).toBeUndefined();
+      });
+
+      it('should return undefined (not throw) when getRepoDefaultBranch fails', async () => {
+        (TFSServices.getItemContentWithHeaders as jest.Mock)
+          .mockResolvedValueOnce({ data: { value: [] }, headers: {} }); // same-branch
+
+        (TFSServices.getItemContent as jest.Mock)
+          .mockRejectedValueOnce(new Error('repo not found'))            // getRepoDefaultBranch throws
+          .mockResolvedValueOnce({ value: [] });                         // GetPipelineRunHistory (legacy path)
+
+        const result = await pipelinesDataProvider.findPreviousPipeline(
+          'project1',
+          '123',
+          100,
+          featureTargetPipelineRun
+        );
+
+        expect(result).toBeUndefined();
+      });
+
+      it('should not invoke ancestry walk when same-branch search finds a match', async () => {
+        (TFSServices.getItemContentWithHeaders as jest.Mock).mockResolvedValueOnce({
+          data: { value: [buildCandidate(90, 'refs/heads/feature/x')] },
+          headers: {},
+        });
+
+        const getItemContentSpy = jest.spyOn(TFSServices, 'getItemContent');
+
+        const result = await pipelinesDataProvider.findPreviousPipeline(
+          'project1',
+          '123',
+          100,
+          featureTargetPipelineRun
+        );
+
+        expect(result).toBe(90);
+        // getRepoDefaultBranch / getMergeBase are called via getItemContent — none should be called
+        const ancestryCalls = getItemContentSpy.mock.calls.filter(
+          ([url]) => typeof url === 'string' && (url.includes('git/repositories') && !url.includes('_apis/build'))
+        );
+        expect(ancestryCalls).toHaveLength(0);
+      });
+
+      it('should return undefined (not throw) when getMergeBase returns no commonCommit', async () => {
+        (TFSServices.getItemContentWithHeaders as jest.Mock)
+          .mockResolvedValueOnce({ data: { value: [] }, headers: {} }); // same-branch
+
+        (TFSServices.getItemContent as jest.Mock)
+          .mockResolvedValueOnce({ defaultBranch: 'refs/heads/main' })  // getRepoDefaultBranch
+          .mockResolvedValueOnce({})                                     // getMergeBase returns no commonCommit
+          .mockResolvedValueOnce({ value: [] });                         // GetPipelineRunHistory (legacy path)
+
+        const result = await pipelinesDataProvider.findPreviousPipeline(
+          'project1',
+          '123',
+          100,
+          featureTargetPipelineRun
+        );
+
+        expect(result).toBeUndefined();
+      });
     });
   });
 


### PR DESCRIPTION
…name

- Drop `findPreviousSuccessfulBuildPage` any-branch call from `findPreviousPipeline`; return undefined when same-branch search yields no match instead of falling back across branches.
- Before building the repo API URL in pipeline resource collection, resolve the project name via `normalizeProjectName` so encoded or ID-based names are replaced with canonical display names.
- Update tests to reflect single-call expectations and the new "no cross-branch" behaviour.