### PR TITLE
Improve with more workitems

### DIFF
--- a/src/modules/GitDataProvider.ts
+++ b/src/modules/GitDataProvider.ts
@@ -932,6 +932,33 @@ export default class GitDataProvider {
 
             extendedCommit['commit'] = commit;
 
+            // commitsbatch only returns WIs linked from the commit side (e.g. commit message "#123").
+            // WIs linked from the WI development section are missing. Enrich via the per-commit
+            // /workItems endpoint which resolves bidirectional links.
+            // Build a local normalized copy so the raw API response object is never mutated.
+            const mergedWorkItems: { id: any; url: string }[] = Array.isArray(commit.workItems)
+              ? commit.workItems.map((wi: any) => ({ id: wi?.id, url: wi?.url }))
+              : [];
+            try {
+              const perCommitWiUrl = `${gitUrl}/commits/${commit.commitId}/workItems?api-version=5.1`;
+              const perCommitWiRes = await TFSServices.getItemContent(perCommitWiUrl, this.token);
+              if (Array.isArray(perCommitWiRes?.value) && perCommitWiRes.value.length > 0) {
+                // Normalize to string keys to handle number/string inconsistency across API versions.
+                const existingIds = new Set(mergedWorkItems.map((wi) => String(wi.id)));
+                for (const wi of perCommitWiRes.value) {
+                  if (wi?.id != null && !existingIds.has(String(wi.id))) {
+                    mergedWorkItems.push({ id: wi.id, url: wi.url });
+                    existingIds.add(String(wi.id));
+                  }
+                }
+              }
+            } catch (enrichErr: any) {
+              logger.warn(
+                `GetCommitBatch per-commit WI enrichment failed for ${commit.commitId}: ${enrichErr?.message}`
+              );
+            }
+            commit.workItems = mergedWorkItems;
+
             const workItemIds = Array.isArray(commit.workItems)
               ? commit.workItems.map((wi: any) => wi?.id).filter(Boolean).join(',')
               : '';

--- a/src/tests/modules/gitDataProvider.test.ts
+++ b/src/tests/modules/gitDataProvider.test.ts
@@ -1558,6 +1558,151 @@ describe('GitDataProvider - GetCommitBatch', () => {
     expect(result).toHaveLength(0);
   });
 
+  it('should enrich commit workItems with WIs linked from WI development section', async () => {
+    // commitsbatch returns only the commit-side linked WI (e.g. from commit message "#277476").
+    // WIs linked from the WI side (ADO development section) must be merged via the per-commit
+    // /workItems endpoint.
+    const gitUrl = 'https://dev.azure.com/org/project/_apis/git/repositories/repo-id';
+    const itemVersion = { version: 'main', versionType: 'branch' };
+    const compareVersion = { version: 'v1.0.0', versionType: 'tag' };
+
+    const mockCommitsResponse = {
+      data: {
+        count: 1,
+        value: [
+          {
+            commitId: 'd465de7abc',
+            committer: { name: 'Dev', date: '2024-01-01T00:00:00Z' },
+            comment: 'fix: link WI-277476',
+            workItems: [{ id: 277476, url: 'https://tfs/wi/277476' }],
+          },
+        ],
+      },
+    };
+    const mockEmptyPage = { data: { count: 0, value: [] } };
+    // Per-commit endpoint returns the 2 WI-side linked items in addition to the commit-side one.
+    const mockPerCommitWi = {
+      value: [
+        { id: 277476, url: 'https://tfs/wi/277476' }, // duplicate — must be deduplicated
+        { id: 285957, url: 'https://tfs/wi/285957' },
+        { id: 284959, url: 'https://tfs/wi/284959' },
+      ],
+    };
+
+    (TFSServices as any).postRequest
+      .mockResolvedValueOnce(mockCommitsResponse)
+      .mockResolvedValueOnce(mockEmptyPage);
+    (TFSServices.getItemContent as jest.Mock).mockResolvedValueOnce(mockPerCommitWi);
+
+    const result = await gitDataProvider.GetCommitBatch(gitUrl, itemVersion, compareVersion);
+
+    expect(result).toHaveLength(1);
+    const workItems = result[0].commit.workItems;
+    const ids = workItems.map((wi: any) => wi.id).sort((a: number, b: number) => a - b);
+    expect(ids).toEqual([277476, 284959, 285957]);
+    // Per-commit endpoint was called with correct URL
+    expect(TFSServices.getItemContent).toHaveBeenCalledWith(
+      `${gitUrl}/commits/d465de7abc/workItems?api-version=5.1`,
+      mockToken
+    );
+  });
+
+  it('should handle per-commit WI enrichment failure gracefully and log a warning', async () => {
+    const gitUrl = 'https://dev.azure.com/org/project/_apis/git/repositories/repo-id';
+    const itemVersion = { version: 'main', versionType: 'branch' };
+    const compareVersion = { version: 'v1.0.0', versionType: 'tag' };
+
+    const mockCommitsResponse = {
+      data: {
+        count: 1,
+        value: [
+          {
+            commitId: 'aabbcc',
+            committer: { name: 'Dev', date: '2024-01-01T00:00:00Z' },
+            comment: 'fix',
+            workItems: [{ id: 100, url: 'https://tfs/wi/100' }],
+          },
+        ],
+      },
+    };
+    const mockEmptyPage = { data: { count: 0, value: [] } };
+
+    (TFSServices as any).postRequest
+      .mockResolvedValueOnce(mockCommitsResponse)
+      .mockResolvedValueOnce(mockEmptyPage);
+    (TFSServices.getItemContent as jest.Mock).mockRejectedValueOnce(new Error('network error'));
+
+    const result = await gitDataProvider.GetCommitBatch(gitUrl, itemVersion, compareVersion);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].commit.workItems).toEqual([{ id: 100, url: 'https://tfs/wi/100' }]);
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('per-commit WI enrichment failed'));
+  });
+
+  it('should initialize workItems from absent field when per-commit endpoint returns WIs', async () => {
+    // Commit arrives from commitsbatch with workItems absent (not [] but undefined).
+    const gitUrl = 'https://dev.azure.com/org/project/_apis/git/repositories/repo-id';
+    const itemVersion = { version: 'main', versionType: 'branch' };
+    const compareVersion = { version: 'v1.0.0', versionType: 'tag' };
+
+    const mockCommitsResponse = {
+      data: {
+        count: 1,
+        value: [
+          {
+            commitId: 'ccddee',
+            committer: { name: 'Dev', date: '2024-01-01T00:00:00Z' },
+            comment: 'no commit-side WI',
+            // workItems intentionally absent
+          },
+        ],
+      },
+    };
+    const mockEmptyPage = { data: { count: 0, value: [] } };
+    const mockPerCommitWi = { value: [{ id: 999, url: 'https://tfs/wi/999' }] };
+
+    (TFSServices as any).postRequest
+      .mockResolvedValueOnce(mockCommitsResponse)
+      .mockResolvedValueOnce(mockEmptyPage);
+    (TFSServices.getItemContent as jest.Mock).mockResolvedValueOnce(mockPerCommitWi);
+
+    const result = await gitDataProvider.GetCommitBatch(gitUrl, itemVersion, compareVersion);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].commit.workItems.map((wi: any) => wi.id)).toEqual([999]);
+  });
+
+  it('should leave workItems unchanged when per-commit endpoint returns empty list', async () => {
+    const gitUrl = 'https://dev.azure.com/org/project/_apis/git/repositories/repo-id';
+    const itemVersion = { version: 'main', versionType: 'branch' };
+    const compareVersion = { version: 'v1.0.0', versionType: 'tag' };
+
+    const mockCommitsResponse = {
+      data: {
+        count: 1,
+        value: [
+          {
+            commitId: 'ff0011',
+            committer: { name: 'Dev', date: '2024-01-01T00:00:00Z' },
+            comment: 'fix',
+            workItems: [{ id: 42, url: 'https://tfs/wi/42' }],
+          },
+        ],
+      },
+    };
+    const mockEmptyPage = { data: { count: 0, value: [] } };
+
+    (TFSServices as any).postRequest
+      .mockResolvedValueOnce(mockCommitsResponse)
+      .mockResolvedValueOnce(mockEmptyPage);
+    (TFSServices.getItemContent as jest.Mock).mockResolvedValueOnce({ value: [] });
+
+    const result = await gitDataProvider.GetCommitBatch(gitUrl, itemVersion, compareVersion);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].commit.workItems.map((wi: any) => wi.id)).toEqual([42]);
+  });
+
   it('should include specificItemPath when provided', async () => {
     // Arrange
     const gitUrl = 'https://dev.azure.com/org/project/_apis/git/repositories/repo-id';


### PR DESCRIPTION
  1. String-normalized Set — both existingIds initialization and the per-commit loop now use String(wi.id), preventing number/string type mismatch from letting duplicates through
  2. No raw mutation — mergedWorkItems is built as a local copy; commit.workItems is assigned once at the end, never mutated in-place
  3. Logged warn on failure — catch (enrichErr) now calls logger.warn(...) so failures surface in production logs
  4. Two new tests — absent workItems field initialized correctly; empty per-commit response leaves original unchanged