### PR TITLE
  test(git): assert warn fires on missing project.id fallback; remove…

### DIFF
--- a/src/modules/GitDataProvider.ts
+++ b/src/modules/GitDataProvider.ts
@@ -932,13 +932,6 @@ export default class GitDataProvider {
 
             extendedCommit['commit'] = commit;
 
-            const workItemIds = Array.isArray(commit.workItems)
-              ? commit.workItems.map((wi: any) => wi?.id).filter(Boolean).join(',')
-              : '';
-            logger.info(
-              `GetCommitBatch commit ${String(commit.commitId || '').substring(0, 7)} workItems=[${workItemIds}]`
-            );
-
             let committerName = commit.committer.name;
             let commitDate = commit.committer.date.toString().slice(0, 10);
             extendedCommit['committerName'] = committerName;

--- a/src/tests/modules/gitDataProvider.test.ts
+++ b/src/tests/modules/gitDataProvider.test.ts
@@ -1417,6 +1417,9 @@ describe('GitDataProvider - getItemsForPipelineRange', () => {
       expect.stringContaining(pipelineTeamProject),
       expect.any(String)
     );
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining(`falling back to pipeline teamProject=${pipelineTeamProject}`)
+    );
   });
 });
 


### PR DESCRIPTION
… debug log

  - Add logger.warn assertion to cross-project teamProject fallback test
  - Remove per-commit logger.info from GetCommitBatch hot path