### PR TITLE
#291467 Shared Steps - flatten numbering, remove title row

### DIFF
--- a/src/models/tfs-data.ts
+++ b/src/models/tfs-data.ts
@@ -218,6 +218,7 @@ export function createBugRelation(id: string, title: string, severity?: string):
 export class TestSteps {
   stepId: string;
   stepPosition: string;
+  originalStepPosition?: string;
   action: string;
   expected: string;
   isSharedStepTitle: boolean;

--- a/src/modules/ResultDataProvider.ts
+++ b/src/modules/ResultDataProvider.ts
@@ -5008,6 +5008,7 @@ export default class ResultDataProvider {
           const step = stepMap.get(actionResult.stepIdentifier);
           if (step) {
             actionResult.stepPosition = step.stepPosition;
+            actionResult.originalStepPosition = step.originalStepPosition;
             actionResult.action = step.action;
             actionResult.expected = step.expected;
             actionResult.isSharedStepTitle = step.isSharedStepTitle;

--- a/src/tests/utils/testStepParserHelper.test.ts
+++ b/src/tests/utils/testStepParserHelper.test.ts
@@ -130,10 +130,10 @@ describe('TestStepParserHelper', () => {
         `${mockOrgUrl}/_apis/wit/workitems/999/revisions/5`,
         mockToken
       );
-      expect(result).toHaveLength(2); // Title + 1 step
-      expect(result[0].isSharedStepTitle).toBe(true);
-      expect(result[0].action).toContain('Shared Step Title');
-      expect(result[1].action).toBe('Shared Step Action');
+      expect(result).toHaveLength(1); // shared step only (no title row)
+      expect(result[0].isSharedStepTitle).toBe(false);
+      expect(result[0].action).toBe('Shared Step Action');
+      expect(result[0].stepPosition).toBe('1');
     });
 
     it('should parse shared steps without revision lookup', async () => {
@@ -170,7 +170,7 @@ describe('TestStepParserHelper', () => {
         `${mockOrgUrl}/_apis/wit/workitems/999`,
         mockToken
       );
-      expect(result).toHaveLength(2);
+      expect(result).toHaveLength(1); // shared step only (no title row)
     });
 
     it('should handle shared step fetch error by logging and rethrowing', async () => {
@@ -273,11 +273,12 @@ describe('TestStepParserHelper', () => {
       const result = await testStepParserHelper.parseTestSteps(xmlSteps, sharedStepIdToRevisionLookupMap);
 
       // Assert
-      expect(result).toHaveLength(3); // 1 regular + 1 title + 1 shared step
+      expect(result).toHaveLength(2); // 1 regular + 1 shared substep (no title row)
       expect(result[0].stepId).toBe('1');
       expect(result[0].action).toBe('Regular Step');
-      expect(result[1].isSharedStepTitle).toBe(true);
-      expect(result[2].action).toBe('Nested Shared Action');
+      expect(result[0].stepPosition).toBe('1');
+      expect(result[1].action).toBe('Nested Shared Action');
+      expect(result[1].stepPosition).toBe('2');
     });
 
     it('should handle parent step ID for nested steps', async () => {

--- a/src/utils/testStepParserHelper.ts
+++ b/src/utils/testStepParserHelper.ts
@@ -42,17 +42,10 @@ export default class TestStepParserHelper {
         const stepsList = await this.parseTestSteps(
           stepsXML,
           sharedStepIdToRevisionLookupMap,
-          `${parentStepPosition}.`,
+          parentStepPosition,
           parentStepId
         );
-        const titleObj = {
-          stepId: parentStepId,
-          stepPosition: parentStepPosition,
-          action: `<b>${sharedStepTitle}<b/>`,
-          expected: '',
-          isSharedStepTitle: true,
-        };
-        sharedStepsList = [titleObj, ...stepsList];
+        sharedStepsList = stepsList;
       }
       return sharedStepsList;
     } catch (err: any) {
@@ -164,6 +157,14 @@ export default class TestStepParserHelper {
         level,
         parentStepId
       );
+      if (level === '') {
+        const flatSteps = stepsList.filter((s) => !s.isSharedStepTitle);
+        flatSteps.forEach((step, i) => {
+          step.originalStepPosition = step.stepPosition;
+          step.stepPosition = String(i + 1);
+        });
+        return flatSteps;
+      }
       return stepsList;
     } catch (err: any) {
       logger.error(


### PR DESCRIPTION
Customers need sequential step numbers (1,2,3,4) instead of hierarchical (1,1.1,1.2,2) when shared steps expand inline.

- Remove title row emission from fetchSharedSteps
- Drop dot-prefix in recursive parseTestSteps call
- Post-process at top-level: filter isSharedStepTitle rows, renumber flat, save original as originalStepPosition
- Propagate originalStepPosition onto actionResult