### PR TITLE
#292865 fetch latest WI relations for runless test cases

### DIFF
--- a/src/modules/ResultDataProvider.ts
+++ b/src/modules/ResultDataProvider.ts
@@ -3776,16 +3776,19 @@ export default class ResultDataProvider {
             ?.filter((field: string) => field.includes('@linked'))
             ?.map((field: string) => field.split('@')[0]);
           const selectedLinkedFieldSet = new Set(filteredLinkedFields);
-          const { relations } = testCaseData;
-          if (relations) {
-            await this.appendLinkedRelations(
-              relations,
-              relatedRequirements,
-              relatedBugs,
-              relatedCRs,
-              testCaseData,
-              selectedLinkedFieldSet
-            );
+          if (selectedLinkedFieldSet.size > 0) {
+            const latestWi = await this.fetchWorkItemLatest(projectName, testCaseId, true);
+            const relations = latestWi?.relations ?? testCaseData?.relations;
+            if (relations) {
+              await this.appendLinkedRelations(
+                relations,
+                relatedRequirements,
+                relatedBugs,
+                relatedCRs,
+                testCaseData,
+                selectedLinkedFieldSet
+              );
+            }
           }
           selectedLinkedFieldSet.clear();
         }


### PR DESCRIPTION
Suite testcases API response omits workItem.relations and rarely includes System.Rev, so resolveRunlessTestCaseData falls back to the suite snapshot (relations=[]) and returns early on steps presence — never reaching fetchWorkItemLatest. "Tests" links added after suite load were silently dropped.

Now fetches current WI via fetchWorkItemLatest before appendLinkedRelations when linked fields are selected, guaranteeing up-to-date relations regardless of snapshot resolution path.