### PR TITLE
#292865 include closed work items in linked relations

### DIFF
--- a/src/modules/ResultDataProvider.ts
+++ b/src/modules/ResultDataProvider.ts
@@ -4413,9 +4413,6 @@ export default class ResultDataProvider {
         const relatedUrl = relation.url;
         try {
           const wi = await TFSServices.getItemContent(relatedUrl, this.token);
-          if (wi.fields['System.State'] === 'Closed') {
-            continue;
-          }
           if (
             selectedLinkedFieldSet.has('associatedRequirement') &&
             wi.fields['System.WorkItemType'] === 'Requirement'

--- a/src/tests/modules/ResultDataProvider.test.ts
+++ b/src/tests/modules/ResultDataProvider.test.ts
@@ -5127,7 +5127,7 @@ describe('ResultDataProvider', () => {
   });
 
   describe('appendLinkedRelations', () => {
-    it('should append requirement/bug/cr when enabled and skip closed items', async () => {
+    it('should append requirement/bug/cr when enabled, including closed items', async () => {
       const relations = [
         { rel: 'System.LinkTypes.Related', url: 'https://example.com/wi/1' },
         { rel: 'System.LinkTypes.Related', url: 'https://example.com/wi/2' },
@@ -5191,7 +5191,7 @@ describe('ResultDataProvider', () => {
       expect(relatedRequirements[0]).toEqual(
         expect.objectContaining({ id: 1, customerId: 'CUST-1', workItemType: 'Requirement' })
       );
-      expect(relatedBugs).toHaveLength(1);
+      expect(relatedBugs).toHaveLength(2);
       expect(relatedCRs).toHaveLength(1);
     });
 


### PR DESCRIPTION
Closed requirements are valid traceability targets — closed means accepted/done, not irrelevant. The blanket state filter introduced in #319 silently dropped all linked items in Closed state regardless of work item type, causing requirements to never appear in test reporter output.