### PR TITLE
#294937 - batch-fetch work items in commit range methods

### DIFF
--- a/src/modules/GitDataProvider.ts
+++ b/src/modules/GitDataProvider.ts
@@ -245,32 +245,52 @@ export default class GitDataProvider {
     const commits = Array.isArray(commitRange?.value) ? commitRange.value : [];
     const workItemCommitIds = this.collectWorkItemCommitIds(commits);
     const commitById = includePullRequestWorkItems ? this.buildCommitById(commits) : new Map<string, any>();
-    //extract linked items and append them to result
+    //extract linked items and append them to result — batch-fetch all WIs first
+    const allWiIds: number[] = [];
+    const wiIdSet = new Set<number>();
+    const commitWiPairs: Array<{ commit: any; wiId: number }> = [];
     for (const commit of commits) {
       if (commit.workItems && commit.workItems.length > 0) {
         for (const wi of commit.workItems) {
-          let populatedItem = await this.ticketsDataProvider.GetWorkItem(projectId, wi.id);
-          let linkedItems: LinkedRelation[] = await this.createLinkedRelatedItemsForSVD(
-            linkedWiOptions,
-            populatedItem,
-          );
-          let changeSet: any = { workItem: populatedItem, commit: commit, linkedItems };
-          commitChangesArray.push(changeSet);
-          if (typeof populatedItem?.id === 'number') {
-            addedWorkItemIds.add(populatedItem.id);
+          const wiId = Number(wi.id);
+          if (!wiIdSet.has(wiId)) {
+            wiIdSet.add(wiId);
+            allWiIds.push(wiId);
           }
+          commitWiPairs.push({ commit, wiId });
         }
-      } else {
-        // Handle commits with no linked work items
-        if (includeUnlinkedCommits) {
-          commitsWithNoRelations.push({
-            commitId: commit.commitId,
-            commitDate: commit.committer?.date,
-            committer: commit.committer?.name,
-            comment: commit.comment,
-            url: commit.remoteUrl,
-          });
-        }
+      } else if (includeUnlinkedCommits) {
+        commitsWithNoRelations.push({
+          commitId: commit.commitId,
+          commitDate: commit.committer?.date,
+          committer: commit.committer?.name,
+          comment: commit.comment,
+          url: commit.remoteUrl,
+        });
+      }
+    }
+    const populatedItems = allWiIds.length > 0
+      ? await this.ticketsDataProvider.PopulateWorkItemsByIds(allWiIds, projectId)
+      : [];
+    if (allWiIds.length > 0 && populatedItems.length === 0) {
+      logger.warn(`GetItemsInCommitRange: PopulateWorkItemsByIds returned 0 items for ${allWiIds.length} requested IDs — possible auth failure or API error`);
+    }
+    const populatedById = new Map<number, any>();
+    for (const item of populatedItems) {
+      if (item?.id != null) populatedById.set(item.id, item);
+    }
+    logger.info(`GetItemsInCommitRange: batch-fetched ${populatedById.size} unique work items (${allWiIds.length} requested)`);
+    for (const { commit, wiId } of commitWiPairs) {
+      const populatedItem = populatedById.get(wiId);
+      if (!populatedItem) continue;
+      let linkedItems: LinkedRelation[] = await this.createLinkedRelatedItemsForSVD(
+        linkedWiOptions,
+        populatedItem,
+      );
+      let changeSet: any = { workItem: populatedItem, commit: commit, linkedItems };
+      commitChangesArray.push(changeSet);
+      if (typeof populatedItem?.id === 'number') {
+        addedWorkItemIds.add(populatedItem.id);
       }
     }
     logger.info(
@@ -511,7 +531,10 @@ export default class GitDataProvider {
           );
         }
       }
-      //Then extend the commit information with the related WIs
+      //Then extend the commit information with the related WIs — batch-fetch all WIs first
+      const pipelineWiIds: number[] = [];
+      const pipelineWiIdSet = new Set<number>();
+      const pipelineCommitWiPairs: Array<{ commit: any; wiId: number }> = [];
       for (const extendedCommit of extendedCommits) {
         const { commit } = extendedCommit;
         if (!Array.isArray(commit.workItems) || commit.workItems.length === 0) {
@@ -527,24 +550,41 @@ export default class GitDataProvider {
           continue;
         }
         for (const wi of commit.workItems) {
-          const populatedWorkItem = await this.ticketsDataProvider.GetWorkItem(
-            targetRepo['projectId'],
-            wi.id,
-          );
-          let linkedItems: LinkedRelation[] = await this.createLinkedRelatedItemsForSVD(
-            linkedWiOptions,
-            populatedWorkItem,
-          );
-          let changeSet: any = {
-            workItem: populatedWorkItem,
-            commit: commit,
-            targetRepo,
-            linkedItems,
-          };
-          if (!addedWorkItemByIdSet.has(wi.id)) {
-            addedWorkItemByIdSet.add(wi.id);
-            commitChangesArray.push(changeSet);
+          const wiId = Number(wi.id);
+          if (!pipelineWiIdSet.has(wiId)) {
+            pipelineWiIdSet.add(wiId);
+            pipelineWiIds.push(wiId);
           }
+          pipelineCommitWiPairs.push({ commit, wiId });
+        }
+      }
+      const pipelinePopulated = pipelineWiIds.length > 0
+        ? await this.ticketsDataProvider.PopulateWorkItemsByIds(pipelineWiIds, targetRepo['projectId'])
+        : [];
+      if (pipelineWiIds.length > 0 && pipelinePopulated.length === 0) {
+        logger.warn(`getItemsForPipelineRange: PopulateWorkItemsByIds returned 0 items for ${pipelineWiIds.length} requested IDs — possible auth failure or API error`);
+      }
+      const pipelinePopulatedById = new Map<number, any>();
+      for (const item of pipelinePopulated) {
+        if (item?.id != null) pipelinePopulatedById.set(item.id, item);
+      }
+      logger.info(`getItemsForPipelineRange: batch-fetched ${pipelinePopulatedById.size} unique work items (${pipelineWiIds.length} requested)`);
+      for (const { commit, wiId } of pipelineCommitWiPairs) {
+        const populatedWorkItem = pipelinePopulatedById.get(wiId);
+        if (!populatedWorkItem) continue;
+        let linkedItems: LinkedRelation[] = await this.createLinkedRelatedItemsForSVD(
+          linkedWiOptions,
+          populatedWorkItem,
+        );
+        let changeSet: any = {
+          workItem: populatedWorkItem,
+          commit: commit,
+          targetRepo,
+          linkedItems,
+        };
+        if (!addedWorkItemByIdSet.has(wiId)) {
+          addedWorkItemByIdSet.add(wiId);
+          commitChangesArray.push(changeSet);
         }
       }
 

--- a/src/modules/JfrogDataProvider.ts
+++ b/src/modules/JfrogDataProvider.ts
@@ -14,8 +14,11 @@ export default class JfrogDataProvider {
   }
 
   async getServiceConnectionUrlByConnectionId(teamProject: string, connectionId: string) {
-    let url = `${this.orgUrl}${teamProject}/_apis/serviceendpoint/endpoints/${connectionId}?api-version=6`;
+    let url = `${this.orgUrl}${teamProject}/_apis/serviceendpoint/endpoints/${connectionId}?api-version=7.1`;
     const serviceConnectionResponse = await TFSServices.getItemContent(url, this.tfsToken);
+    if (!serviceConnectionResponse?.url) {
+      throw new Error(`Service connection ${connectionId} returned no URL — identity may lack service-endpoint read permission`);
+    }
     logger.debug(`service connection url ${JSON.stringify(serviceConnectionResponse.url)}`);
     return serviceConnectionResponse.url;
   }
@@ -23,6 +26,11 @@ export default class JfrogDataProvider {
   async getCiDataFromJfrog(jfrogUrl: string, buildName: string, buildVersion: string): Promise<string> {
     let jfrogHeader: any = {};
     try {
+      if (!jfrogUrl) {
+        throw new Error(
+          `JFrog service connection URL is unresolved for build "${buildName}" — the caller identity may lack service-endpoint read permission`
+        );
+      }
       if (this.jfrogToken !== '') {
         jfrogHeader['Authorization'] = `Bearer ${this.jfrogToken}`;
       }
@@ -42,6 +50,9 @@ export default class JfrogDataProvider {
         this.jfrogToken !== ''
           ? await TFSServices.getJfrogRequest(getCiRequestUrl, jfrogHeader)
           : await TFSServices.getJfrogRequest(getCiRequestUrl);
+      if (!getCiResponse?.buildInfo?.url) {
+        throw new Error(`JFrog response for build "${buildName}${buildVersion}" is missing buildInfo.url`);
+      }
       logger.debug(`CI Url from JFROG: ${getCiResponse.buildInfo.url}`);
       return getCiResponse.buildInfo.url;
     } catch (err: any) {

--- a/src/modules/TicketsDataProvider.ts
+++ b/src/modules/TicketsDataProvider.ts
@@ -2365,7 +2365,7 @@ export default class TicketsDataProvider {
     const postBatch = (currentIds: any[]) =>
       this.withHistoricalApiVersionFallback('populate-workitems-batch', (apiVersion) =>
         TFSServices.getItemContent(this.appendApiVersion(baseUrl, apiVersion), this.token, 'post', {
-          $expand: 'Relations',
+          $expand: 'All',
           ids: currentIds,
         }),
       ).then(({ result }) => result);

--- a/src/tests/modules/JfrogDataProvider.test.ts
+++ b/src/tests/modules/JfrogDataProvider.test.ts
@@ -33,7 +33,7 @@ describe('JfrogDataProvider', () => {
 
       // Assert
       expect(TFSServices.getItemContent).toHaveBeenCalledWith(
-        `${mockOrgUrl}${mockTeamProject}/_apis/serviceendpoint/endpoints/${mockConnectionId}?api-version=6`,
+        `${mockOrgUrl}${mockTeamProject}/_apis/serviceendpoint/endpoints/${mockConnectionId}?api-version=7.1`,
         mockTfsToken
       );
       expect(logger.debug).toHaveBeenCalledWith(`service connection url "${mockResponse.url}"`);

--- a/src/tests/modules/gitDataProvider.test.ts
+++ b/src/tests/modules/gitDataProvider.test.ts
@@ -1129,8 +1129,8 @@ describe('GitDataProvider - GetItemsInCommitRange', () => {
     const mockPRsResponse = { count: 0, value: [] };
 
     (TFSServices.getItemContent as jest.Mock)
-      .mockResolvedValueOnce(mockPopulatedWI)
-      .mockResolvedValueOnce(mockPRsResponse);
+      .mockResolvedValueOnce({ value: [mockPopulatedWI] }) // batch POST for work items
+      .mockResolvedValueOnce(mockPRsResponse);             // GetPullRequestsLinkedItemsInCommitRange (default: includePullRequestWorkItems=true)
 
     // Act
     const result = await gitDataProvider.GetItemsInCommitRange(projectId, repoId, commitRange, null, false);
@@ -1248,7 +1248,7 @@ describe('GitDataProvider - getItemsForPipelineRange', () => {
 
     (TFSServices.getItemContent as jest.Mock)
       .mockResolvedValueOnce(mockRepoData)
-      .mockResolvedValueOnce(mockPopulatedWI);
+      .mockResolvedValueOnce({ value: [mockPopulatedWI] }); // batch POST for work items
 
     // Act
     const result = await gitDataProvider.getItemsForPipelineRange(
@@ -1320,8 +1320,7 @@ describe('GitDataProvider - getItemsForPipelineRange', () => {
 
     (TFSServices.getItemContent as jest.Mock)
       .mockResolvedValueOnce(mockRepoData)
-      .mockResolvedValueOnce(mockPopulatedWI)
-      .mockResolvedValueOnce(mockPopulatedWI);
+      .mockResolvedValueOnce({ value: [mockPopulatedWI] }); // single batch POST (WI id=1 deduped)
 
     // Act
     const result = await gitDataProvider.getItemsForPipelineRange(
@@ -1361,8 +1360,8 @@ describe('GitDataProvider - getItemsForPipelineRange', () => {
     const mockPopulatedWI = { id: 42, fields: { 'System.Title': 'Cross-project WI' } };
 
     (TFSServices.getItemContent as jest.Mock)
-      .mockResolvedValueOnce(mockRepoDataNoCrossLink) // repo metadata call
-      .mockResolvedValueOnce(mockPopulatedWI);        // GetWorkItem call
+      .mockResolvedValueOnce(mockRepoDataNoCrossLink)        // repo metadata call
+      .mockResolvedValueOnce({ value: [mockPopulatedWI] }); // batch POST for work items
 
     const result = await gitDataProvider.getItemsForPipelineRange(
       pipelineTeamProject,
@@ -1373,10 +1372,12 @@ describe('GitDataProvider - getItemsForPipelineRange', () => {
 
     expect(result.commitChangesArray).toHaveLength(1);
     expect(result.commitChangesArray[0].workItem.id).toBe(42);
-    // GetWorkItem should have been called with the repo's own projectId from repoData.project.id
+    // batch POST URL contains the repo's projectId (cross-project-id)
     expect(TFSServices.getItemContent).toHaveBeenCalledWith(
       expect.stringContaining('cross-project-id'),
-      expect.any(String)
+      expect.any(String),
+      'post',
+      expect.objectContaining({ ids: expect.any(Array) })
     );
   });
 
@@ -1401,7 +1402,7 @@ describe('GitDataProvider - getItemsForPipelineRange', () => {
 
     (TFSServices.getItemContent as jest.Mock)
       .mockResolvedValueOnce(mockRepoDataEmpty)
-      .mockResolvedValueOnce(mockPopulatedWI);
+      .mockResolvedValueOnce({ value: [mockPopulatedWI] }); // batch POST for work items
 
     const result = await gitDataProvider.getItemsForPipelineRange(
       pipelineTeamProject,
@@ -1412,10 +1413,12 @@ describe('GitDataProvider - getItemsForPipelineRange', () => {
 
     expect(result.commitChangesArray).toHaveLength(1);
     expect(result.commitChangesArray[0].workItem.id).toBe(99);
-    // GetWorkItem should have been called with the pipeline teamProject as fallback
+    // batch POST URL contains the fallback teamProject
     expect(TFSServices.getItemContent).toHaveBeenCalledWith(
       expect.stringContaining(pipelineTeamProject),
-      expect.any(String)
+      expect.any(String),
+      'post',
+      expect.objectContaining({ ids: expect.any(Array) })
     );
     expect(logger.warn).toHaveBeenCalledWith(
       expect.stringContaining(`falling back to pipeline teamProject=${pipelineTeamProject}`)
@@ -1774,9 +1777,9 @@ describe('GitDataProvider - createLinkedRelatedItemsForSVD (via GetItemsInCommit
     const mockPRsResponse = { count: 0, value: [] };
 
     (TFSServices.getItemContent as jest.Mock)
-      .mockResolvedValueOnce(mockPopulatedWI)
-      .mockResolvedValueOnce(mockRelatedWI)
-      .mockResolvedValueOnce(mockPRsResponse);
+      .mockResolvedValueOnce({ value: [mockPopulatedWI] }) // batch POST for work items
+      .mockResolvedValueOnce(mockRelatedWI)                // GetWorkItemByUrl (linked relation)
+      .mockResolvedValueOnce(mockPRsResponse);             // GetPullRequestsLinkedItemsInCommitRange
 
     // Act
     const result = await gitDataProvider.GetItemsInCommitRange(
@@ -1826,8 +1829,8 @@ describe('GitDataProvider - createLinkedRelatedItemsForSVD (via GetItemsInCommit
     const mockPRsResponse = { count: 0, value: [] };
 
     (TFSServices.getItemContent as jest.Mock)
-      .mockResolvedValueOnce(mockPopulatedWI)
-      .mockResolvedValueOnce(mockPRsResponse);
+      .mockResolvedValueOnce({ value: [mockPopulatedWI] }) // batch POST for work items
+      .mockResolvedValueOnce(mockPRsResponse);             // GetPullRequestsLinkedItemsInCommitRange
 
     // Act
     const result = await gitDataProvider.GetItemsInCommitRange(
@@ -1877,8 +1880,8 @@ describe('GitDataProvider - createLinkedRelatedItemsForSVD (via GetItemsInCommit
     const mockPRsResponse = { count: 0, value: [] };
 
     (TFSServices.getItemContent as jest.Mock)
-      .mockResolvedValueOnce(mockPopulatedWI)
-      .mockResolvedValueOnce(mockPRsResponse);
+      .mockResolvedValueOnce({ value: [mockPopulatedWI] }) // batch POST for work items
+      .mockResolvedValueOnce(mockPRsResponse);             // GetPullRequestsLinkedItemsInCommitRange
 
     // Act
     const result = await gitDataProvider.GetItemsInCommitRange(
@@ -1936,9 +1939,9 @@ describe('GitDataProvider - createLinkedRelatedItemsForSVD (via GetItemsInCommit
     const mockPRsResponse = { count: 0, value: [] };
 
     (TFSServices.getItemContent as jest.Mock)
-      .mockResolvedValueOnce(mockPopulatedWI)
-      .mockResolvedValueOnce(mockRelatedWI)
-      .mockResolvedValueOnce(mockPRsResponse);
+      .mockResolvedValueOnce({ value: [mockPopulatedWI] }) // batch POST for work items
+      .mockResolvedValueOnce(mockRelatedWI)                // GetWorkItemByUrl (linked relation)
+      .mockResolvedValueOnce(mockPRsResponse);             // GetPullRequestsLinkedItemsInCommitRange
 
     // Act
     const result = await gitDataProvider.GetItemsInCommitRange(
@@ -2105,9 +2108,8 @@ describe('GitDataProvider - duplicate work item removal', () => {
     const mockPRsResponse = { count: 0, value: [] };
 
     (TFSServices.getItemContent as jest.Mock)
-      .mockResolvedValueOnce(mockPopulatedWI)
-      .mockResolvedValueOnce(mockPopulatedWI)
-      .mockResolvedValueOnce(mockPRsResponse);
+      .mockResolvedValueOnce({ value: [mockPopulatedWI] }) // batch POST (WI id=1 deduped from 2 commits)
+      .mockResolvedValueOnce(mockPRsResponse);             // GetPullRequestsLinkedItemsInCommitRange
 
     // Act
     const result = await gitDataProvider.GetItemsInCommitRange(projectId, repoId, commitRange, null, false);


### PR DESCRIPTION
Serial GetWorkItem per commit caused N round-trips per range query. Collect all WI IDs first, call PopulateWorkItemsByIds once per range, then resolve from the in-memory map.

Also expand $expand to 'All' in PopulateWorkItemsByIds for full field coverage, and add early-error guards in JfrogDataProvider for missing service connection URL and buildInfo.url.