### PR TITLE
#297488 - add GetTraceColumnsByType for schema-based per-side column …

### DIFF
--- a/src/modules/TicketsDataProvider.ts
+++ b/src/modules/TicketsDataProvider.ts
@@ -3478,4 +3478,129 @@ export default class TicketsDataProvider {
       throw err;
     }
   }
+
+  /**
+   * Returns per-side valid column lists for trace analysis Column Settings dialog.
+   * Uses the WIT field schema (~6 ADO calls, constant cost) to determine which
+   * declared query columns are valid for the Requirement side vs the Test Case side.
+   *
+   * Known limitation: assumes one WIT type per side (determined by sampling the first
+   * source + first target work item). Trace queries are single-type per side in practice.
+   */
+  async GetTraceColumnsByType(
+    reqTestWiqlHref: string | undefined,
+    testReqWiqlHref: string | undefined,
+    project: string,
+  ): Promise<{ Requirement: any[]; 'Test Case': any[] }> {
+    const normalizeCols = (columns: any[]): any[] =>
+      (columns || []).map((c: any) => ({
+        referenceName: c.referenceName,
+        name: c.name,
+      }));
+
+    const mergeCols = (a: any[], b: any[]): any[] => {
+      const seen = new Set<string>();
+      const result: any[] = [];
+      for (const col of [...a, ...b]) {
+        if (!seen.has(col.referenceName)) {
+          seen.add(col.referenceName);
+          result.push(col);
+        }
+      }
+      return result;
+    };
+
+    // Sample one work item to read its System.WorkItemType.
+    // In OneHop query relations: !relation.source means root (target = source WI);
+    // relation.source present means link (target = target WI).
+    const sampleWitType = async (relations: any[], isSource: boolean): Promise<string | undefined> => {
+      let url: string | undefined;
+      if (isSource) {
+        const rootRel = relations.find((r) => !r.source && r.target?.url);
+        url = rootRel?.target?.url;
+      } else {
+        const linkRel = relations.find((r) => r.source && r.target?.url);
+        url = linkRel?.target?.url;
+      }
+      if (!url) return undefined;
+      try {
+        const wi: any = await TFSServices.getItemContent(url, this.token);
+        return wi?.fields?.['System.WorkItemType'];
+      } catch {
+        return undefined;
+      }
+    };
+
+    const fetchTypeFieldSet = async (typeName: string): Promise<Set<string>> => {
+      const query = new URLSearchParams({ 'api-version': '5.1' }).toString();
+      const url = `${this.orgUrl}${encodeURIComponent(project)}/_apis/wit/workitemtypes/${encodeURIComponent(typeName)}/fields?${query}`;
+      const res = await TFSServices.getItemContent(url, this.token);
+      const fields = res?.value ?? [];
+      return new Set<string>((fields as any[]).map((f: any) => f.referenceName));
+    };
+
+    try {
+      // Step 1: fetch declared columns from provided query hrefs
+      let reqTestCols: any[] = [];
+      let testReqCols: any[] = [];
+      let reqTestRelations: any[] = [];
+      let testReqRelations: any[] = [];
+
+      if (reqTestWiqlHref) {
+        const qr: any = await TFSServices.getItemContent(reqTestWiqlHref, this.token);
+        reqTestCols = normalizeCols(qr?.columns || []);
+        reqTestRelations = qr?.workItemRelations || [];
+      }
+      if (testReqWiqlHref) {
+        const qr: any = await TFSServices.getItemContent(testReqWiqlHref, this.token);
+        testReqCols = normalizeCols(qr?.columns || []);
+        testReqRelations = qr?.workItemRelations || [];
+      }
+
+      const declaredCols = mergeCols(reqTestCols, testReqCols);
+      if (declaredCols.length === 0) {
+        return { Requirement: [], 'Test Case': [] };
+      }
+
+      // Step 2: sample WIT type names
+      // reqTest: source = Requirement, target = Test Case
+      // testReq: source = Test Case, target = Requirement
+      let reqTypeName: string | undefined;
+      let tcTypeName: string | undefined;
+
+      if (reqTestRelations.length > 0) {
+        [reqTypeName, tcTypeName] = await Promise.all([
+          sampleWitType(reqTestRelations, true),
+          sampleWitType(reqTestRelations, false),
+        ]);
+      }
+      if ((!reqTypeName || !tcTypeName) && testReqRelations.length > 0) {
+        const [tSrc, tTgt] = await Promise.all([
+          sampleWitType(testReqRelations, true),
+          sampleWitType(testReqRelations, false),
+        ]);
+        if (!tcTypeName) tcTypeName = tSrc;
+        if (!reqTypeName) reqTypeName = tTgt;
+      }
+
+      if (!reqTypeName || !tcTypeName) {
+        logger.warn('GetTraceColumnsByType: could not determine WIT type names — returning merged columns');
+        return { Requirement: declaredCols, 'Test Case': declaredCols };
+      }
+
+      // Step 3: fetch WIT field schemas and intersect with declared columns
+      const [reqFieldSet, tcFieldSet] = await Promise.all([
+        fetchTypeFieldSet(reqTypeName),
+        fetchTypeFieldSet(tcTypeName),
+      ]);
+
+      return {
+        Requirement: declaredCols.filter((c) => reqFieldSet.has(c.referenceName)),
+        'Test Case': declaredCols.filter((c) => tcFieldSet.has(c.referenceName)),
+      };
+    } catch (err: any) {
+      logger.error(`GetTraceColumnsByType failed: ${err.message}`);
+      return { Requirement: [], 'Test Case': [] };
+    }
+  }
 }

--- a/src/tests/modules/ticketsDataProvider.traceColumns.test.ts
+++ b/src/tests/modules/ticketsDataProvider.traceColumns.test.ts
@@ -1,0 +1,192 @@
+import { TFSServices } from '../../helpers/tfs';
+import TicketsDataProvider from '../../modules/TicketsDataProvider';
+import logger from '../../utils/logger';
+
+jest.mock('../../helpers/tfs');
+jest.mock('../../utils/logger');
+
+const mockGetItemContent = TFSServices.getItemContent as jest.Mock;
+
+// Minimal OneHop query result shape
+const makeQueryResult = (columns: any[], relations: any[]) => ({
+  columns,
+  workItemRelations: relations,
+  queryType: 'oneHop',
+});
+
+// Root relation (source = the root WI, no .source field)
+const rootRelation = (targetId: number, targetUrl: string) => ({
+  source: null,
+  target: { id: targetId, url: targetUrl },
+});
+
+// Link relation (source WI → target WI)
+const linkRelation = (sourceId: number, targetId: number, targetUrl: string) => ({
+  source: { id: sourceId },
+  target: { id: targetId, url: targetUrl },
+});
+
+const REQ_COLS = [
+  { referenceName: 'System.Id', name: 'ID' },
+  { referenceName: 'System.Title', name: 'Title' },
+  { referenceName: 'Custom.CustomerRequirementId', name: 'CustomerRequirementId' },
+  { referenceName: 'Microsoft.VSTS.Common.Priority', name: 'Priority' },
+];
+
+const TC_COLS = [
+  { referenceName: 'System.Id', name: 'ID' },
+  { referenceName: 'System.Title', name: 'Title' },
+  { referenceName: 'Microsoft.VSTS.TCM.AutomationStatus', name: 'Automation Status' },
+  { referenceName: 'Microsoft.VSTS.Common.Priority', name: 'Priority' },
+];
+
+const REQ_FIELDS_SCHEMA = {
+  value: [
+    { referenceName: 'System.Id' },
+    { referenceName: 'System.Title' },
+    { referenceName: 'Custom.CustomerRequirementId' },
+    { referenceName: 'Microsoft.VSTS.Common.Priority' },
+  ],
+};
+
+const TC_FIELDS_SCHEMA = {
+  value: [
+    { referenceName: 'System.Id' },
+    { referenceName: 'System.Title' },
+    { referenceName: 'Microsoft.VSTS.TCM.AutomationStatus' },
+    { referenceName: 'Microsoft.VSTS.Common.Priority' },
+    // Note: Custom.CustomerRequirementId is NOT in TC schema
+  ],
+};
+
+describe('TicketsDataProvider.GetTraceColumnsByType', () => {
+  let provider: TicketsDataProvider;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    provider = new TicketsDataProvider('https://dev.azure.com/org/', 'mock-token');
+  });
+
+  it('splits columns correctly: CustomerRequirementId in Requirement only, not Test Case', async () => {
+    const reqRelations = [
+      rootRelation(1, 'https://ado/wi/1'),
+      linkRelation(1, 101, 'https://ado/wi/101'),
+    ];
+    const reqQueryResult = makeQueryResult(REQ_COLS, reqRelations);
+
+    mockGetItemContent
+      .mockResolvedValueOnce(reqQueryResult)                          // reqTest wiql fetch
+      .mockResolvedValueOnce({ fields: { 'System.WorkItemType': 'Requirement' } }) // source WI sample
+      .mockResolvedValueOnce({ fields: { 'System.WorkItemType': 'Test Case' } })   // target WI sample
+      .mockResolvedValueOnce(REQ_FIELDS_SCHEMA)                       // Requirement type fields
+      .mockResolvedValueOnce(TC_FIELDS_SCHEMA);                       // Test Case type fields
+
+    const result = await provider.GetTraceColumnsByType(
+      'https://ado/wiql/reqtest',
+      undefined,
+      'my-project',
+    );
+
+    const reqRefs = result.Requirement.map((c: any) => c.referenceName);
+    const tcRefs = result['Test Case'].map((c: any) => c.referenceName);
+
+    expect(reqRefs).toContain('Custom.CustomerRequirementId');
+    expect(tcRefs).not.toContain('Custom.CustomerRequirementId');
+    expect(reqRefs).toContain('Microsoft.VSTS.Common.Priority');
+    expect(tcRefs).toContain('Microsoft.VSTS.Common.Priority');
+  });
+
+  it('merges columns from both queries (reqTest + testReq), deduped', async () => {
+    const reqRelations = [rootRelation(1, 'https://ado/wi/1'), linkRelation(1, 101, 'https://ado/wi/101')];
+    const testRelations = [rootRelation(101, 'https://ado/wi/101'), linkRelation(101, 1, 'https://ado/wi/1')];
+
+    const extraCol = { referenceName: 'System.AreaPath', name: 'Area Path' };
+
+    mockGetItemContent
+      .mockResolvedValueOnce(makeQueryResult(REQ_COLS, reqRelations))          // reqTest wiql
+      .mockResolvedValueOnce(makeQueryResult([...TC_COLS, extraCol], testRelations)) // testReq wiql
+      .mockResolvedValueOnce({ fields: { 'System.WorkItemType': 'Requirement' } })  // source sample reqTest
+      .mockResolvedValueOnce({ fields: { 'System.WorkItemType': 'Test Case' } })    // target sample reqTest
+      .mockResolvedValueOnce(REQ_FIELDS_SCHEMA)
+      .mockResolvedValueOnce({ value: [...TC_FIELDS_SCHEMA.value, { referenceName: 'System.AreaPath' }] });
+
+    const result = await provider.GetTraceColumnsByType(
+      'https://ado/wiql/reqtest',
+      'https://ado/wiql/testreq',
+      'my-project',
+    );
+
+    const tcRefs = result['Test Case'].map((c: any) => c.referenceName);
+    expect(tcRefs).toContain('System.AreaPath'); // came only from testReq columns
+  });
+
+  it('raw display names passed through without rename (no CustomerRequirementId → Customer ID)', async () => {
+    const reqRelations = [rootRelation(1, 'https://ado/wi/1'), linkRelation(1, 101, 'https://ado/wi/101')];
+
+    mockGetItemContent
+      .mockResolvedValueOnce(makeQueryResult(REQ_COLS, reqRelations))
+      .mockResolvedValueOnce({ fields: { 'System.WorkItemType': 'Requirement' } })
+      .mockResolvedValueOnce({ fields: { 'System.WorkItemType': 'Test Case' } })
+      .mockResolvedValueOnce(REQ_FIELDS_SCHEMA)
+      .mockResolvedValueOnce(TC_FIELDS_SCHEMA);
+
+    const result = await provider.GetTraceColumnsByType('https://ado/wiql/reqtest', undefined, 'proj');
+
+    const custCol = result.Requirement.find((c: any) => c.referenceName === 'Custom.CustomerRequirementId');
+    expect(custCol?.name).toBe('CustomerRequirementId'); // raw ADO name, NOT 'Customer ID'
+  });
+
+  it('gracefully degrades when WIT type cannot be sampled (no relations) — returns merged columns both sides', async () => {
+    const emptyRelations: any[] = [];
+
+    mockGetItemContent.mockResolvedValueOnce(makeQueryResult(REQ_COLS, emptyRelations));
+
+    const result = await provider.GetTraceColumnsByType('https://ado/wiql/reqtest', undefined, 'proj');
+
+    const reqRefs = result.Requirement.map((c: any) => c.referenceName);
+    const tcRefs = result['Test Case'].map((c: any) => c.referenceName);
+    // Both sides get the merged declared columns as fallback
+    expect(reqRefs).toContain('Custom.CustomerRequirementId');
+    expect(tcRefs).toContain('Custom.CustomerRequirementId');
+  });
+
+  it('returns empty arrays when wiql fetch fails', async () => {
+    mockGetItemContent.mockRejectedValueOnce(new Error('Network error'));
+
+    const result = await provider.GetTraceColumnsByType('https://ado/wiql/reqtest', undefined, 'proj');
+
+    expect(result).toEqual({ Requirement: [], 'Test Case': [] });
+    expect((logger.error as jest.Mock)).toHaveBeenCalled();
+  });
+
+  it('returns empty arrays when schema fetch fails', async () => {
+    const reqRelations = [rootRelation(1, 'https://ado/wi/1'), linkRelation(1, 101, 'https://ado/wi/101')];
+
+    mockGetItemContent
+      .mockResolvedValueOnce(makeQueryResult(REQ_COLS, reqRelations))
+      .mockResolvedValueOnce({ fields: { 'System.WorkItemType': 'Requirement' } })
+      .mockResolvedValueOnce({ fields: { 'System.WorkItemType': 'Test Case' } })
+      .mockRejectedValueOnce(new Error('ADO 404')); // schema fetch fails
+
+    const result = await provider.GetTraceColumnsByType('https://ado/wiql/reqtest', undefined, 'proj');
+
+    expect(result).toEqual({ Requirement: [], 'Test Case': [] });
+  });
+
+  it('handles undefined schema value gracefully (no crash on null response)', async () => {
+    const reqRelations = [rootRelation(1, 'https://ado/wi/1'), linkRelation(1, 101, 'https://ado/wi/101')];
+
+    mockGetItemContent
+      .mockResolvedValueOnce(makeQueryResult(REQ_COLS, reqRelations))
+      .mockResolvedValueOnce({ fields: { 'System.WorkItemType': 'Requirement' } })
+      .mockResolvedValueOnce({ fields: { 'System.WorkItemType': 'Test Case' } })
+      .mockResolvedValueOnce(undefined)   // schema returns undefined (null guard fix)
+      .mockResolvedValueOnce(undefined);
+
+    const result = await provider.GetTraceColumnsByType('https://ado/wiql/reqtest', undefined, 'proj');
+
+    // Both field sets are empty → both sides empty after intersection
+    expect(result.Requirement).toEqual([]);
+    expect(result['Test Case']).toEqual([]);
+  });
+});


### PR DESCRIPTION
…verification

Samples one source and one target work item to resolve WIT type names, fetches each type's field schema from ADO, and intersects with the declared query columns to return per-side Requirement / Test Case lists. Gracefully degrades to merged columns when relations are empty or sampling fails. Includes 7 tests covering split correctness, dedup, raw name passthrough, and all failure paths.