### PR TITLE
#297488 - per-direction trace columns + query definition API

### DIFF
--- a/src/modules/TicketsDataProvider.ts
+++ b/src/modules/TicketsDataProvider.ts
@@ -1673,6 +1673,20 @@ export default class TicketsDataProvider {
     return await this.GetQueryResultsByWiqlHref(wiql.href, project);
   }
 
+  async GetQueryDefinitionById(
+    queryId: string,
+    project: string,
+  ): Promise<{ id: string; name: string; columns: any[]; wiql: any }> {
+    const url = `${this.orgUrl}${project}/_apis/wit/queries/${encodeURIComponent(queryId)}?$expand=all`;
+    const def: any = await TFSServices.getItemContent(url, this.token);
+    return {
+      id: def?.id ?? queryId,
+      name: def?.name ?? '',
+      columns: def?.columns ?? [],
+      wiql: def?._links?.wiql ?? null,
+    };
+  }
+
   private normalizeHistoricalAsOf(value: string): string {
     const raw = String(value || '').trim();
     if (!raw) {
@@ -3491,24 +3505,12 @@ export default class TicketsDataProvider {
     reqTestWiqlHref: string | undefined,
     testReqWiqlHref: string | undefined,
     project: string,
-  ): Promise<{ Requirement: any[]; 'Test Case': any[] }> {
+  ): Promise<{ 'req-test'?: { Requirement: any[]; 'Test Case': any[] }; 'test-req'?: { Requirement: any[]; 'Test Case': any[] } }> {
     const normalizeCols = (columns: any[]): any[] =>
       (columns || []).map((c: any) => ({
         referenceName: c.referenceName,
         name: c.name,
       }));
-
-    const mergeCols = (a: any[], b: any[]): any[] => {
-      const seen = new Set<string>();
-      const result: any[] = [];
-      for (const col of [...a, ...b]) {
-        if (!seen.has(col.referenceName)) {
-          seen.add(col.referenceName);
-          result.push(col);
-        }
-      }
-      return result;
-    };
 
     // Sample one work item to read its System.WorkItemType.
     // In OneHop query relations: !relation.source means root (target = source WI);
@@ -3539,68 +3541,69 @@ export default class TicketsDataProvider {
       return new Set<string>((fields as any[]).map((f: any) => f.referenceName));
     };
 
+    // Resolve per-side columns for one query independently.
+    // srcIsReq: true = source WI is Requirement (req-test query), false = source WI is Test Case (test-req query).
+    const resolveQuerySides = async (
+      cols: any[],
+      relations: any[],
+      srcIsReq: boolean,
+    ): Promise<{ Requirement: any[]; 'Test Case': any[] }> => {
+      if (cols.length === 0) return { Requirement: [], 'Test Case': [] };
+      if (relations.length === 0) {
+        // No items to sample — degrade to declared columns on both sides
+        return { Requirement: cols, 'Test Case': cols };
+      }
+      const [srcType, tgtType] = await Promise.all([
+        sampleWitType(relations, true),
+        sampleWitType(relations, false),
+      ]);
+      const reqType = srcIsReq ? srcType : tgtType;
+      const tcType = srcIsReq ? tgtType : srcType;
+      if (!reqType || !tcType) {
+        logger.warn('GetTraceColumnsByType: could not determine WIT type names — returning declared columns for both sides');
+        return { Requirement: cols, 'Test Case': cols };
+      }
+      const [reqFieldSet, tcFieldSet] = await Promise.all([
+        fetchTypeFieldSet(reqType),
+        fetchTypeFieldSet(tcType),
+      ]);
+      return {
+        Requirement: cols.filter((c) => reqFieldSet.has(c.referenceName)),
+        'Test Case': cols.filter((c) => tcFieldSet.has(c.referenceName)),
+      };
+    };
+
     try {
-      // Step 1: fetch declared columns from provided query hrefs
-      let reqTestCols: any[] = [];
-      let testReqCols: any[] = [];
-      let reqTestRelations: any[] = [];
-      let testReqRelations: any[] = [];
+      const result: { 'req-test'?: { Requirement: any[]; 'Test Case': any[] }; 'test-req'?: { Requirement: any[]; 'Test Case': any[] } } = {};
 
       if (reqTestWiqlHref) {
-        const qr: any = await TFSServices.getItemContent(reqTestWiqlHref, this.token);
-        reqTestCols = normalizeCols(qr?.columns || []);
-        reqTestRelations = qr?.workItemRelations || [];
+        try {
+          const qr: any = await TFSServices.getItemContent(reqTestWiqlHref, this.token);
+          const cols = normalizeCols(qr?.columns || []);
+          const relations = qr?.workItemRelations || [];
+          result['req-test'] = await resolveQuerySides(cols, relations, true);
+        } catch (err: any) {
+          logger.error(`GetTraceColumnsByType[req-test] failed: ${err.message}`);
+          result['req-test'] = { Requirement: [], 'Test Case': [] };
+        }
       }
+
       if (testReqWiqlHref) {
-        const qr: any = await TFSServices.getItemContent(testReqWiqlHref, this.token);
-        testReqCols = normalizeCols(qr?.columns || []);
-        testReqRelations = qr?.workItemRelations || [];
+        try {
+          const qr: any = await TFSServices.getItemContent(testReqWiqlHref, this.token);
+          const cols = normalizeCols(qr?.columns || []);
+          const relations = qr?.workItemRelations || [];
+          result['test-req'] = await resolveQuerySides(cols, relations, false);
+        } catch (err: any) {
+          logger.error(`GetTraceColumnsByType[test-req] failed: ${err.message}`);
+          result['test-req'] = { Requirement: [], 'Test Case': [] };
+        }
       }
 
-      const declaredCols = mergeCols(reqTestCols, testReqCols);
-      if (declaredCols.length === 0) {
-        return { Requirement: [], 'Test Case': [] };
-      }
-
-      // Step 2: sample WIT type names
-      // reqTest: source = Requirement, target = Test Case
-      // testReq: source = Test Case, target = Requirement
-      let reqTypeName: string | undefined;
-      let tcTypeName: string | undefined;
-
-      if (reqTestRelations.length > 0) {
-        [reqTypeName, tcTypeName] = await Promise.all([
-          sampleWitType(reqTestRelations, true),
-          sampleWitType(reqTestRelations, false),
-        ]);
-      }
-      if ((!reqTypeName || !tcTypeName) && testReqRelations.length > 0) {
-        const [tSrc, tTgt] = await Promise.all([
-          sampleWitType(testReqRelations, true),
-          sampleWitType(testReqRelations, false),
-        ]);
-        if (!tcTypeName) tcTypeName = tSrc;
-        if (!reqTypeName) reqTypeName = tTgt;
-      }
-
-      if (!reqTypeName || !tcTypeName) {
-        logger.warn('GetTraceColumnsByType: could not determine WIT type names — returning merged columns');
-        return { Requirement: declaredCols, 'Test Case': declaredCols };
-      }
-
-      // Step 3: fetch WIT field schemas and intersect with declared columns
-      const [reqFieldSet, tcFieldSet] = await Promise.all([
-        fetchTypeFieldSet(reqTypeName),
-        fetchTypeFieldSet(tcTypeName),
-      ]);
-
-      return {
-        Requirement: declaredCols.filter((c) => reqFieldSet.has(c.referenceName)),
-        'Test Case': declaredCols.filter((c) => tcFieldSet.has(c.referenceName)),
-      };
+      return result;
     } catch (err: any) {
       logger.error(`GetTraceColumnsByType failed: ${err.message}`);
-      return { Requirement: [], 'Test Case': [] };
+      return {};
     }
   }
 }

--- a/src/tests/modules/ticketsDataProvider.traceColumns.test.ts
+++ b/src/tests/modules/ticketsDataProvider.traceColumns.test.ts
@@ -87,8 +87,8 @@ describe('TicketsDataProvider.GetTraceColumnsByType', () => {
       'my-project',
     );
 
-    const reqRefs = result.Requirement.map((c: any) => c.referenceName);
-    const tcRefs = result['Test Case'].map((c: any) => c.referenceName);
+    const reqRefs = result['req-test']!.Requirement.map((c: any) => c.referenceName);
+    const tcRefs = result['req-test']!['Test Case'].map((c: any) => c.referenceName);
 
     expect(reqRefs).toContain('Custom.CustomerRequirementId');
     expect(tcRefs).not.toContain('Custom.CustomerRequirementId');
@@ -96,19 +96,27 @@ describe('TicketsDataProvider.GetTraceColumnsByType', () => {
     expect(tcRefs).toContain('Microsoft.VSTS.Common.Priority');
   });
 
-  it('merges columns from both queries (reqTest + testReq), deduped', async () => {
+  it('resolves each query independently: req-test and test-req have separate column sets', async () => {
     const reqRelations = [rootRelation(1, 'https://ado/wi/1'), linkRelation(1, 101, 'https://ado/wi/101')];
     const testRelations = [rootRelation(101, 'https://ado/wi/101'), linkRelation(101, 1, 'https://ado/wi/1')];
 
     const extraCol = { referenceName: 'System.AreaPath', name: 'Area Path' };
+    const tcSchemaWithAreaPath = { value: [...TC_FIELDS_SCHEMA.value, { referenceName: 'System.AreaPath' }] };
 
     mockGetItemContent
+      // req-test query processing
       .mockResolvedValueOnce(makeQueryResult(REQ_COLS, reqRelations))          // reqTest wiql
+      .mockResolvedValueOnce({ fields: { 'System.WorkItemType': 'Requirement' } })  // source sample
+      .mockResolvedValueOnce({ fields: { 'System.WorkItemType': 'Test Case' } })    // target sample
+      .mockResolvedValueOnce(REQ_FIELDS_SCHEMA)                                     // Req schema
+      .mockResolvedValueOnce(tcSchemaWithAreaPath)                                  // TC schema
+      // test-req query processing (srcIsReq=false: source=TC, target=Req)
       .mockResolvedValueOnce(makeQueryResult([...TC_COLS, extraCol], testRelations)) // testReq wiql
-      .mockResolvedValueOnce({ fields: { 'System.WorkItemType': 'Requirement' } })  // source sample reqTest
-      .mockResolvedValueOnce({ fields: { 'System.WorkItemType': 'Test Case' } })    // target sample reqTest
-      .mockResolvedValueOnce(REQ_FIELDS_SCHEMA)
-      .mockResolvedValueOnce({ value: [...TC_FIELDS_SCHEMA.value, { referenceName: 'System.AreaPath' }] });
+      .mockResolvedValueOnce({ fields: { 'System.WorkItemType': 'Test Case' } })     // source sample (TC)
+      .mockResolvedValueOnce({ fields: { 'System.WorkItemType': 'Requirement' } })   // target sample (Req)
+      // Promise.all([fetchTypeFieldSet(reqType), fetchTypeFieldSet(tcType)]): reqType=Requirement first
+      .mockResolvedValueOnce(REQ_FIELDS_SCHEMA)                                      // Req schema (first in Promise.all)
+      .mockResolvedValueOnce(tcSchemaWithAreaPath);                                  // TC schema (second in Promise.all)
 
     const result = await provider.GetTraceColumnsByType(
       'https://ado/wiql/reqtest',
@@ -116,8 +124,12 @@ describe('TicketsDataProvider.GetTraceColumnsByType', () => {
       'my-project',
     );
 
-    const tcRefs = result['Test Case'].map((c: any) => c.referenceName);
-    expect(tcRefs).toContain('System.AreaPath'); // came only from testReq columns
+    // req-test: columns from REQ_COLS only — no extraCol
+    const reqTestTcRefs = result['req-test']!['Test Case'].map((c: any) => c.referenceName);
+    expect(reqTestTcRefs).not.toContain('System.AreaPath');
+    // test-req: columns from TC_COLS+extraCol — System.AreaPath present
+    const testReqTcRefs = result['test-req']!['Test Case'].map((c: any) => c.referenceName);
+    expect(testReqTcRefs).toContain('System.AreaPath');
   });
 
   it('raw display names passed through without rename (no CustomerRequirementId → Customer ID)', async () => {
@@ -132,7 +144,7 @@ describe('TicketsDataProvider.GetTraceColumnsByType', () => {
 
     const result = await provider.GetTraceColumnsByType('https://ado/wiql/reqtest', undefined, 'proj');
 
-    const custCol = result.Requirement.find((c: any) => c.referenceName === 'Custom.CustomerRequirementId');
+    const custCol = result['req-test']!.Requirement.find((c: any) => c.referenceName === 'Custom.CustomerRequirementId');
     expect(custCol?.name).toBe('CustomerRequirementId'); // raw ADO name, NOT 'Customer ID'
   });
 
@@ -143,9 +155,9 @@ describe('TicketsDataProvider.GetTraceColumnsByType', () => {
 
     const result = await provider.GetTraceColumnsByType('https://ado/wiql/reqtest', undefined, 'proj');
 
-    const reqRefs = result.Requirement.map((c: any) => c.referenceName);
-    const tcRefs = result['Test Case'].map((c: any) => c.referenceName);
-    // Both sides get the merged declared columns as fallback
+    const reqRefs = result['req-test']!.Requirement.map((c: any) => c.referenceName);
+    const tcRefs = result['req-test']!['Test Case'].map((c: any) => c.referenceName);
+    // Both sides get this query's declared columns as fallback (no sampling possible)
     expect(reqRefs).toContain('Custom.CustomerRequirementId');
     expect(tcRefs).toContain('Custom.CustomerRequirementId');
   });
@@ -155,7 +167,7 @@ describe('TicketsDataProvider.GetTraceColumnsByType', () => {
 
     const result = await provider.GetTraceColumnsByType('https://ado/wiql/reqtest', undefined, 'proj');
 
-    expect(result).toEqual({ Requirement: [], 'Test Case': [] });
+    expect(result).toEqual({ 'req-test': { Requirement: [], 'Test Case': [] } });
     expect((logger.error as jest.Mock)).toHaveBeenCalled();
   });
 
@@ -170,7 +182,7 @@ describe('TicketsDataProvider.GetTraceColumnsByType', () => {
 
     const result = await provider.GetTraceColumnsByType('https://ado/wiql/reqtest', undefined, 'proj');
 
-    expect(result).toEqual({ Requirement: [], 'Test Case': [] });
+    expect(result).toEqual({ 'req-test': { Requirement: [], 'Test Case': [] } });
   });
 
   it('handles undefined schema value gracefully (no crash on null response)', async () => {
@@ -186,7 +198,7 @@ describe('TicketsDataProvider.GetTraceColumnsByType', () => {
     const result = await provider.GetTraceColumnsByType('https://ado/wiql/reqtest', undefined, 'proj');
 
     // Both field sets are empty → both sides empty after intersection
-    expect(result.Requirement).toEqual([]);
-    expect(result['Test Case']).toEqual([]);
+    expect(result['req-test']!.Requirement).toEqual([]);
+    expect(result['req-test']!['Test Case']).toEqual([]);
   });
 });


### PR DESCRIPTION
TicketsDataProvider.GetTraceColumns: change return type from flat { Requirement, 'Test Case' } to { 'req-test'?: {...}, 'test-req'?: {...} }. Extract resolveQuerySides helper — resolves Requirement and Test Case column sets independently per query direction using WI relations.

Add GetQueryDefinitionById: fetches ADO query definition (id, name, columns, wiql link) via _apis/wit/queries/:id?$expand=all.

Tests: update fixtures and assertions to match per-direction return shape.