### PR TITLE
#297677 -  re-fetch depth-boundary folders with empty children array

### DIFF
--- a/src/modules/TicketsDataProvider.ts
+++ b/src/modules/TicketsDataProvider.ts
@@ -1225,7 +1225,7 @@ export default class TicketsDataProvider {
   }
 
   private async ensureQueryChildren(node: any): Promise<any> {
-    if (!node || !node.hasChildren || node.children) {
+    if (!node || !node.hasChildren || (Array.isArray(node.children) && node.children.length > 0)) {
       return node;
     }
 


### PR DESCRIPTION
ensureQueryChildren guarded on `node.children` (truthy). ADO returns `children: []` for depth-2 boundary folders — empty array is truthy in JS, so the guard treated the folder as already-loaded and skipped the re-fetch. Sub-folder queries were never found.

Fix: guard now requires a non-empty array to skip re-fetch:
  Array.isArray(node.children) && node.children.length > 0

Genuinely empty folders remain protected by the `!node.hasChildren` guard.