### PR TITLE
#297677 - sort historical query results depth-descending for correct …

### DIFF
--- a/src/modules/TicketsDataProvider.ts
+++ b/src/modules/TicketsDataProvider.ts
@@ -2211,6 +2211,9 @@ export default class TicketsDataProvider {
     const normalizedRoot = this.normalizeHistoricalQueryRoot(root);
     const items = (await this.collectHistoricalQueries(normalizedRoot)).filter((query) => query.id !== '');
     items.sort((a, b) => {
+      const aDepth = a.path.split('/').length;
+      const bDepth = b.path.split('/').length;
+      if (aDepth !== bDepth) return bDepth - aDepth;
       const byPath = a.path.localeCompare(b.path);
       if (byPath !== 0) return byPath;
       return a.queryName.localeCompare(b.queryName);


### PR DESCRIPTION
…tree order

Folders appeared after queries at every level because path-ascending sort put 'Shared Queries' before 'Shared Queries/Folder A', causing leaf queries to be inserted into the tree before their sibling folder nodes.

Sort now depth-descending first so sub-folder queries are processed by buildHistoricalQueryTree before same-level leaf queries.