### PR TITLE
#297488 - request explicit fields param for computed ADO columns in t…

### DIFF
--- a/src/modules/TicketsDataProvider.ts
+++ b/src/modules/TicketsDataProvider.ts
@@ -1614,7 +1614,11 @@ export default class TicketsDataProvider {
     resultedRefNameMap: Map<string, string>,
     isRelation: boolean,
   ) {
-    const url = isRelation ? `${receivedObject.target.url}` : `${receivedObject.url}`;
+    const baseUrl = isRelation ? `${receivedObject.target.url}` : `${receivedObject.url}`;
+    // Computed/read-only fields (e.g. System.NodeName) are only populated by ADO when explicitly
+    // requested via `fields=`; a plain GET omits them even though they're declared query columns.
+    const requestedFields = new Set([...columnMap.keys(), 'System.WorkItemType', 'System.Title']);
+    const url = `${baseUrl}?fields=${Array.from(requestedFields).join(',')}`;
     const wi: any = await TFSServices.getItemContent(url, this.token);
     if (!wi) {
       throw new Error(`WI ${isRelation ? receivedObject.target.id : receivedObject.id} not found`);
@@ -3281,6 +3285,7 @@ export default class TicketsDataProvider {
           parsedFields[fieldName] = value;
         }
       }
+
       item.fields = { ...parsedFields };
     } catch (err: any) {
       logger.error(`Cannot filter columns: ${err.message}`);

--- a/src/tests/modules/ticketsDataProvider.test.ts
+++ b/src/tests/modules/ticketsDataProvider.test.ts
@@ -913,6 +913,45 @@ describe('TicketsDataProvider', () => {
     });
   });
 
+  describe('fetchWIForQueryResult', () => {
+    it('should request an explicit fields param including declared columns and forced fields', async () => {
+      (TFSServices.getItemContent as jest.Mock).mockReset();
+      (TFSServices.getItemContent as jest.Mock).mockResolvedValueOnce({
+        id: 1,
+        fields: { 'System.WorkItemType': 'Requirement', 'System.Title': 'T', 'System.NodeName': 'My Node' },
+      });
+      const columnMap = new Map<string, string>([['System.NodeName', 'Node Name']]);
+      const resultedRefNameMap = new Map<string, string>();
+
+      await (ticketsDataProvider as any).fetchWIForQueryResult(
+        { target: { id: 1, url: 'https://example.com/wi/1' } },
+        columnMap,
+        resultedRefNameMap,
+        true,
+      );
+
+      const calledUrl = (TFSServices.getItemContent as jest.Mock).mock.calls[0][0];
+      expect(calledUrl).toContain('https://example.com/wi/1?fields=');
+      expect(calledUrl).toContain('System.NodeName');
+      expect(calledUrl).toContain('System.WorkItemType');
+      expect(calledUrl).toContain('System.Title');
+    });
+
+    it('should throw when the fetched work item is falsy', async () => {
+      (TFSServices.getItemContent as jest.Mock).mockReset();
+      (TFSServices.getItemContent as jest.Mock).mockResolvedValueOnce(null);
+
+      await expect(
+        (ticketsDataProvider as any).fetchWIForQueryResult(
+          { target: { id: 1, url: 'https://example.com/wi/1' } },
+          new Map(),
+          new Map(),
+          true,
+        ),
+      ).rejects.toThrow('WI 1 not found');
+    });
+  });
+
   describe('isFlatQueryAllowedByTypeOrId', () => {
     it('should accept when allowedTypes is empty and WIQL references [System.WorkItemType]', async () => {
       const wiql = "SELECT * FROM WorkItems WHERE [System.WorkItemType] = 'Bug'";


### PR DESCRIPTION
…race tables

Computed/read-only fields like System.NodeName (leaf segment of System.AreaPath) are only populated by ADO when named explicitly in a `fields=` request param — a plain GET omits them even when declared as a query column. fetchWIForQueryResult did a bare GET per work item, so such fields were silently dropped from generated tables despite being selectable in the Column Settings dialog and present in the ADO query itself.

Build the fields param from the query's declared columns plus the force-included System.WorkItemType/System.Title, matching the pattern already used in initTreeQueryResultItem/initFlatQueryResultItem.