### PR TITLE
#298810 -  Sort trace analysis rows by the ADO query's ORDER BY (sort…

### DIFF
--- a/src/modules/TicketsDataProvider.ts
+++ b/src/modules/TicketsDataProvider.ts
@@ -1274,11 +1274,31 @@ export default class TicketsDataProvider {
     }
   }
 
+  private compareFieldValues(a: any, b: any): number {
+    const aMissing = a === undefined || a === null || a === '';
+    const bMissing = b === undefined || b === null || b === '';
+    if (aMissing && bMissing) return 0;
+    if (aMissing) return 1; // missing values sort last
+    if (bMissing) return -1;
+    if (typeof a === 'number' && typeof b === 'number') return a - b;
+    return String(a).localeCompare(String(b), undefined, { numeric: true, sensitivity: 'base' });
+  }
+
+  private compareBySortColumns(a: any, b: any, sortColumns: any[]): number {
+    for (const sortColumn of sortColumns) {
+      const referenceName = sortColumn?.field?.referenceName;
+      if (!referenceName) continue;
+      const cmp = this.compareFieldValues(a?.fields?.[referenceName], b?.fields?.[referenceName]);
+      if (cmp !== 0) return sortColumn.descending ? -cmp : cmp;
+    }
+    return 0;
+  }
+
   private async parseDirectLinkedQueryResultForTableFormat(
     queryResult: QueryTree,
     testCaseToRelatedWiMap: Map<number, Set<any>>,
   ) {
-    const { columns, workItemRelations } = queryResult;
+    const { columns, workItemRelations, sortColumns } = queryResult;
 
     if (workItemRelations?.length === 0) {
       throw new Error('No related work items were found');
@@ -1399,8 +1419,22 @@ export default class TicketsDataProvider {
     }
 
     columnsToShowMap.clear();
+
+    // Apply the ADO query's ORDER BY (sortColumns) to the resolved rows — otherwise rows
+    // render in relation-fetch order regardless of how the user sorted the query in ADO.
+    let orderedSourceTargetsMap = sourceTargetsMap;
+    if (sortColumns && sortColumns.length > 0) {
+      const sortedEntries = [...sourceTargetsMap.entries()].sort(([sourceA], [sourceB]) =>
+        this.compareBySortColumns(sourceA, sourceB, sortColumns),
+      );
+      orderedSourceTargetsMap = new Map(sortedEntries);
+      for (const targets of orderedSourceTargetsMap.values()) {
+        targets.sort((targetA, targetB) => this.compareBySortColumns(targetA, targetB, sortColumns));
+      }
+    }
+
     return {
-      sourceTargetsMap,
+      sourceTargetsMap: orderedSourceTargetsMap,
       sortingSourceColumnsMap: columnSourceMap,
       sortingTargetsColumnsMap: columnTargetsMap,
     };
@@ -1427,7 +1461,7 @@ export default class TicketsDataProvider {
   }
 
   private async parseFlatQueryResultForTableFormat(queryResult: QueryTree) {
-    const { columns, workItems } = queryResult;
+    const { columns, workItems, sortColumns } = queryResult;
 
     if (workItems?.length === 0) {
       throw new Error('No work items were found');
@@ -1459,8 +1493,16 @@ export default class TicketsDataProvider {
     }
 
     columnsToShowMap.clear();
+
+    // Apply the ADO query's ORDER BY (sortColumns) — otherwise rows render in fetch order
+    // regardless of how the user sorted the query in ADO.
+    let orderedWorkItems = [...wiSet];
+    if (sortColumns && sortColumns.length > 0) {
+      orderedWorkItems = orderedWorkItems.sort((a, b) => this.compareBySortColumns(a, b, sortColumns));
+    }
+
     return {
-      fetchedWorkItems: [...wiSet],
+      fetchedWorkItems: orderedWorkItems,
       fieldsToIncludeMap,
     };
   }

--- a/src/tests/modules/ticketsDataProvider.test.ts
+++ b/src/tests/modules/ticketsDataProvider.test.ts
@@ -911,6 +911,44 @@ describe('TicketsDataProvider', () => {
         ),
       ).rejects.toThrow('Target relation is missing');
     });
+
+    it('should order sourceTargetsMap by the query sortColumns (Node Name asc, Customer ID asc)', async () => {
+      // Root work items arrive in relation order 1, 2, 3 — sortColumns should reorder them
+      // by System.NodeName then CustomerRequirementId regardless of fetch order.
+      const rootFieldsById: Record<number, any> = {
+        1: { 'System.WorkItemType': 'Requirement', 'System.NodeName': 'B', CustomerRequirementId: 'C-20' },
+        2: { 'System.WorkItemType': 'Requirement', 'System.NodeName': 'A', CustomerRequirementId: 'C-10' },
+        3: { 'System.WorkItemType': 'Requirement', 'System.NodeName': 'A', CustomerRequirementId: 'C-5' },
+      };
+      jest
+        .spyOn(ticketsDataProvider as any, 'fetchWIForQueryResult')
+        .mockImplementation(async (...args: any[]) => {
+          const rel = args[0];
+          const id = rel?.target?.id ?? rel?.source?.id;
+          return { id, fields: rootFieldsById[id] };
+        });
+
+      const res = await (ticketsDataProvider as any).parseDirectLinkedQueryResultForTableFormat(
+        {
+          queryType: QueryType.OneHop,
+          columns: [],
+          sortColumns: [
+            { field: { referenceName: 'System.NodeName' }, descending: false },
+            { field: { referenceName: 'CustomerRequirementId' }, descending: false },
+          ],
+          workItemRelations: [
+            { source: null, target: { id: 1 } },
+            { source: null, target: { id: 2 } },
+            { source: null, target: { id: 3 } },
+          ],
+        } as any,
+        new Map(),
+      );
+
+      const orderedIds = Array.from(res.sourceTargetsMap.keys()).map((k: any) => k.id);
+      // Expect Node Name A-group (ids 3,2 sorted by Customer ID 5 then 10) before Node Name B (id 1)
+      expect(orderedIds).toEqual([3, 2, 1]);
+    });
   });
 
   describe('fetchWIForQueryResult', () => {
@@ -949,6 +987,45 @@ describe('TicketsDataProvider', () => {
           true,
         ),
       ).rejects.toThrow('WI 1 not found');
+    });
+  });
+
+  describe('parseFlatQueryResultForTableFormat', () => {
+    it('should order fetchedWorkItems by the query sortColumns (Node Name asc, Customer ID asc)', async () => {
+      const fieldsById: Record<number, any> = {
+        1: { 'System.WorkItemType': 'Requirement', 'System.NodeName': 'B', CustomerRequirementId: 'C-20' },
+        2: { 'System.WorkItemType': 'Requirement', 'System.NodeName': 'A', CustomerRequirementId: 'C-10' },
+        3: { 'System.WorkItemType': 'Requirement', 'System.NodeName': 'A', CustomerRequirementId: 'C-5' },
+      };
+      jest
+        .spyOn(ticketsDataProvider as any, 'fetchWIForQueryResult')
+        .mockImplementation(async (...args: any[]) => {
+          const wi = args[0];
+          return { id: wi.id, fields: fieldsById[wi.id] };
+        });
+
+      const res = await (ticketsDataProvider as any).parseFlatQueryResultForTableFormat({
+        queryType: QueryType.Flat,
+        columns: [{ referenceName: 'CustomerRequirementId', name: 'CustomerRequirementId' }],
+        sortColumns: [
+          { field: { referenceName: 'System.NodeName' }, descending: false },
+          { field: { referenceName: 'CustomerRequirementId' }, descending: false },
+        ],
+        workItems: [{ id: 1 }, { id: 2 }, { id: 3 }],
+      } as any);
+
+      const orderedIds = res.fetchedWorkItems.map((wi: any) => wi.id);
+      expect(orderedIds).toEqual([3, 2, 1]);
+    });
+
+    it('should throw when workItems is an empty array', async () => {
+      await expect(
+        (ticketsDataProvider as any).parseFlatQueryResultForTableFormat({
+          queryType: QueryType.Flat,
+          columns: [],
+          workItems: [],
+        } as any),
+      ).rejects.toThrow('No work items were found');
     });
   });
 


### PR DESCRIPTION
…Columns)

Rows previously rendered in relation/fetch order, ignoring the query's configured sort (e.g. Node Name, Customer ID, ID), so Customer ID sort appeared broken. sortColumns was already being fetched from ADO but never consumed. Apply it as a multi-column, numeric-aware comparator to both OneHop (parseDirectLinkedQueryResultForTableFormat) and Flat (parseFlatQueryResultForTableFormat) trace query parsing paths.