### PR TITLE
fix(svd): fetch release-components for the resolved release, not the …

### DIFF
--- a/src/modules/PipelinesDataProvider.ts
+++ b/src/modules/PipelinesDataProvider.ts
@@ -1424,24 +1424,21 @@ export default class PipelinesDataProvider {
     return res;
   }
 
-  async GetRecentReleaseArtifactInfo(projectName: string) {
+  async GetRecentReleaseArtifactInfo(projectName: string, releaseId: number) {
     let artifactInfo: any[] = [];
-    let url: string = `${this.orgUrl}${projectName}/_apis/release/releases?$top=1&api-version=6.0`;
+    if (!Number.isFinite(releaseId) || releaseId <= 0) {
+      return artifactInfo;
+    }
+    let url: string = `${this.orgUrl}${projectName}/_apis/release/releases/${releaseId}?api-version=6.0`;
     if (url.startsWith('https://dev.azure.com')) {
       url = url.replace('https://dev.azure.com', 'https://vsrm.dev.azure.com');
     }
-    let res: any = await TFSServices.getItemContent(url, this.token);
-    const { value: releases } = res;
-    if (releases && releases.length > 0) {
-      const releaseId = releases[0].id;
-      let url: string = `${this.orgUrl}${projectName}/_apis/release/releases/${releaseId}?api-version=6.0`;
-      const releaseResponse = await TFSServices.getItemContent(url, this.token);
-      if (releaseResponse) {
-        const { artifacts } = releaseResponse;
-        for (const artifact of artifacts) {
-          const { definition, version } = artifact.definitionReference;
-          artifactInfo.push({ artifactName: definition.name, artifactVersion: version.name });
-        }
+    const releaseResponse = await TFSServices.getItemContent(url, this.token);
+    if (releaseResponse) {
+      const artifacts = releaseResponse.artifacts || [];
+      for (const artifact of artifacts) {
+        const { definition, version } = artifact.definitionReference;
+        artifactInfo.push({ artifactName: definition.name, artifactVersion: version.name });
       }
     }
     return artifactInfo;

--- a/src/tests/modules/pipelineDataProvider.test.ts
+++ b/src/tests/modules/pipelineDataProvider.test.ts
@@ -951,23 +951,28 @@ describe('PipelinesDataProvider', () => {
   });
 
   describe('GetRecentReleaseArtifactInfo', () => {
-    it('should return empty array when no releases exist', async () => {
+    it('should return empty array when release response has no artifacts', async () => {
       // Arrange
       const projectName = 'project1';
-      const mockResponse = { value: [] };
-      (TFSServices.getItemContent as jest.Mock).mockResolvedValueOnce(mockResponse);
+      const releaseId = 123;
+      const mockReleaseResponse = { artifacts: [] };
+      (TFSServices.getItemContent as jest.Mock).mockResolvedValueOnce(mockReleaseResponse);
 
       // Act
-      const result = await pipelinesDataProvider.GetRecentReleaseArtifactInfo(projectName);
+      const result = await pipelinesDataProvider.GetRecentReleaseArtifactInfo(projectName, releaseId);
 
       // Assert
+      expect(TFSServices.getItemContent).toHaveBeenCalledWith(
+        expect.stringContaining(`releases/${releaseId}`),
+        mockToken
+      );
       expect(result).toEqual([]);
     });
 
-    it('should return artifact info from most recent release', async () => {
+    it('should return artifact info for the specified release', async () => {
       // Arrange
       const projectName = 'project1';
-      const mockReleasesResponse = { value: [{ id: 123 }] };
+      const releaseId = 123;
       const mockReleaseResponse = {
         artifacts: [
           {
@@ -978,15 +983,43 @@ describe('PipelinesDataProvider', () => {
           },
         ],
       };
-      (TFSServices.getItemContent as jest.Mock)
-        .mockResolvedValueOnce(mockReleasesResponse)
-        .mockResolvedValueOnce(mockReleaseResponse);
+      (TFSServices.getItemContent as jest.Mock).mockResolvedValueOnce(mockReleaseResponse);
 
       // Act
-      const result = await pipelinesDataProvider.GetRecentReleaseArtifactInfo(projectName);
+      const result = await pipelinesDataProvider.GetRecentReleaseArtifactInfo(projectName, releaseId);
 
       // Assert
       expect(result).toEqual([{ artifactName: 'artifact1', artifactVersion: '1.0.0' }]);
+    });
+
+    it('should return empty array without calling the API when releaseId is invalid', async () => {
+      // Arrange
+      const projectName = 'project1';
+
+      // Act
+      const resultForZero = await pipelinesDataProvider.GetRecentReleaseArtifactInfo(projectName, 0);
+      const resultForNaN = await pipelinesDataProvider.GetRecentReleaseArtifactInfo(projectName, NaN);
+      const resultForNegative = await pipelinesDataProvider.GetRecentReleaseArtifactInfo(projectName, -5);
+
+      // Assert
+      expect(resultForZero).toEqual([]);
+      expect(resultForNaN).toEqual([]);
+      expect(resultForNegative).toEqual([]);
+      expect(TFSServices.getItemContent).not.toHaveBeenCalled();
+    });
+
+    it('should return empty array when release response has no artifacts field at all', async () => {
+      // Arrange
+      const projectName = 'project1';
+      const releaseId = 123;
+      const mockReleaseResponse = { id: releaseId, name: 'Release-1' };
+      (TFSServices.getItemContent as jest.Mock).mockResolvedValueOnce(mockReleaseResponse);
+
+      // Act
+      const result = await pipelinesDataProvider.GetRecentReleaseArtifactInfo(projectName, releaseId);
+
+      // Assert
+      expect(result).toEqual([]);
     });
   });
 


### PR DESCRIPTION
…project's most recent

GetRecentReleaseArtifactInfo(projectName) always fetched the project's single most recent release via $top=1, ignoring which release range the SVD document was actually generated for. Now takes the resolved release id directly and fetches that specific release (releases/{releaseId}), the same one-call shape already used by GetReleaseByReleaseId.

Adds internal validation (finite, > 0) so an invalid id returns [] without an HTTP call, independent of the caller's own guard -- defense in depth for this package's public API surface, not just its one current caller. Also guards against a release response with no 'artifacts' field at all (previously would throw and get misreported as a lookup failure upstream).